### PR TITLE
Changed URL for Google maps from HTTP to HTTPS

### DIFF
--- a/input/map.html.tmpl
+++ b/input/map.html.tmpl
@@ -4,7 +4,7 @@
 <head>
 <title>AWS Regional Data Centers mapping</title>
 
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
 <script type="text/javascript">
 var map = null;
 var mode = "idle";


### PR DESCRIPTION
Fixes mixed content errors when using SSL and loading via GitHub pages