### PR TITLE
minimal update to Python 3; add "list of closest DCs" as well as "the closest" to outputs

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -7,10 +7,11 @@
 # the License, or (at your option) any later version.
 
 import os
-from string import Template
+from io import open
 from math import *
+from string import Template
 
-MAP_MARKER="""
+MAP_MARKER = """
     var M$num = new google.maps.Marker({
       position: new google.maps.LatLng($latlon),
       map: map,
@@ -19,24 +20,26 @@ MAP_MARKER="""
     M$num.setMap(map);
 """
 
-MAP_LINE="""
+MAP_LINE = """
     var L$num = [ new google.maps.LatLng($e_ll), new google.maps.LatLng($d_ll)];
     var P$num = new google.maps.Polyline({ path: L$num, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P$num.setMap(map);
 """
+
 
 def haversine(lat1, lon1, lat2, lon2):
     """calculate the great circle distance between two points on the earth"""
     lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
     dlon = lon2 - lon1
     dlat = lat2 - lat1
-    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
     c = 2 * asin(sqrt(a))
     km = 6367 * c
     return km
 
+
 class Entry:
-    def __init__(self, code, name, lat, lon, tag=None, datacenter=None):
+    def __init__(self, code, name, lat, lon, tag=None, datacenter=None, alldcs=None):
         self.code = code
         self.name = name
         self.lat = lat
@@ -44,24 +47,35 @@ class Entry:
 
         self.tag = tag
         self.datacenter = datacenter
+        self.alldcs = alldcs
 
     @property
     def latlon(self):
         """convenience property used in map generation"""
         return "%s, %s" % (self.lat, self.lon)
 
+
 class Entries(dict):
     def __init__(self):
         self.datacenters = {}
 
     def _get_closest_datacenter(self, lat, lon):
-        """returns closest regional datacenter using haversine formula"""
+        """returns the closest regional datacenter using haversine formula"""
         distances = {}
         for name, datacenter in self.datacenters.items():
             distance = haversine(lat, lon, datacenter.lat, datacenter.lon)
             distances[distance] = name
 
         return distances[min(distances.keys())]
+
+    def _get_datacenters_ordered_by_closest(self, lat, lon):
+        """returns all the datacenters, ordered by closest to farthest"""
+        distances = {}
+        for name, datacenter in self.datacenters.items():
+            distance = haversine(lat, lon, datacenter.lat, datacenter.lon)
+            distances[distance] = name
+
+        return ",".join(dict(sorted(distances.items())).values())
 
     def add_datacenter(self, code, name, lat, lon):
         """add a regional datacenter"""
@@ -71,12 +85,13 @@ class Entries(dict):
         """add an entry"""
         codetag = "-".join([code, tag])
         datacenter = self._get_closest_datacenter(lat, lon)
-        self[codetag] = Entry(code, name, lat, lon, tag, datacenter)
+        alldcs = self._get_datacenters_ordered_by_closest(lat, lon)
+        self[codetag] = Entry(code, name, lat, lon, tag, datacenter, alldcs)
 
     def override_entry(self, code, name, tag, datacenter):
         """override an entries datacenter or create a new one"""
         codetag = "-".join([code, tag])
-        if self.has_key(codetag):
+        if codetag in self:
             self[codetag].datacenter = datacenter
         else:
             self[codetag] = Entry(code, name, None, None, tag, datacenter)
@@ -87,13 +102,13 @@ class Entries(dict):
 
         for entry in self:
             if entry.tag == tag:
-                print >>fd, "%s;%s;%s" % (entry.code, entry.name, entry.datacenter)
+                fd.write("%s;%s;%s;%s\n" % (entry.code, entry.name, entry.datacenter, entry.alldcs))
 
         fd.close()
 
     def write_map(self, template, cables, output):
         """generate map from template (cables, markers, lines)"""
-        t = Template(file(template).read())
+        t = Template(open(template).read())
 
         # markers
         n = 0
@@ -114,9 +129,9 @@ class Entries(dict):
             d = self.datacenters[e.datacenter]
             lines.append(line.substitute(num=n, e_ll=e.latlon, d_ll=d.latlon))
 
-        html = t.substitute( CABLES=file(cables).read(),
-                             MARKERS="\n".join(markers),
-                             LINES="\n".join(lines) )
+        html = t.substitute(CABLES=open(cables).read(),
+                            MARKERS="\n".join(markers),
+                            LINES="\n".join(lines))
 
         fd = open(output, 'w')
         fd.write(html)
@@ -124,12 +139,13 @@ class Entries(dict):
 
     def __iter__(self):
         """iterate over the dictionary as it if were a sorted list"""
-        return (self[key] for key in iter(sorted(dict.iterkeys(self))))
+        return (self[key] for key in iter(sorted(dict.keys(self))))
+
 
 def main():
     entries = Entries()
 
-    for line in file("input/datacenters").readlines():
+    for line in open("input/datacenters").readlines():
         if line[0] == '#':
             continue
         code, name, lat, lon = line.rstrip().split(";")
@@ -139,15 +155,15 @@ def main():
         if line[0] == '#':
             continue
         tag = os.path.basename(filepath)
-        for line in file(filepath).readlines():
+        for line in open(filepath).readlines():
             code, name, lat, lon = line.rstrip().split(";")
             entries.add_entry(code, name, float(lat), float(lon), tag)
 
-    for line in file("input/overrides").readlines():
+    for line in open("input/overrides").readlines():
         if line[0] == '#':
             continue
         code, tag, name, datacenter = line.rstrip().split(";")
-        if entries.datacenters.has_key(code):
+        if datacenter in entries.datacenters:
             entries.override_entry(code, name, tag, datacenter)
 
     entries.write_index("usa", "output/usa.index")
@@ -157,4 +173,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/input/datacenters
+++ b/input/datacenters
@@ -18,4 +18,4 @@ ap-south-1;Mumbai;19.08;72.88
 ca-central-1;Canada Central;45.5;-73.6
 ap-east-1;Hong Kong;22.27;114.16
 me-south-1;Bahrain;26.10;50.46
-af-south;South Africa;-33.93;18.42
+af-south-1;South Africa;-33.93;18.42

--- a/output/countries.index
+++ b/output/countries.index
@@ -1,256 +1,256 @@
-A1;Anonymous Proxy;us-east-1
-A2;Satellite Provider;us-east-1
-AD;Andorra;eu-south-1
-AE;United Arab Emirates;me-south-1
-AF;Afghanistan;me-south-1
-AG;Antigua and Barbuda;us-east-1
-AI;Anguilla;us-east-1
-AL;Albania;eu-south-1
-AM;Armenia;me-south-1
-AN;Netherlands Antilles;us-east-1
-AO;Angola;eu-west-1
-AP;Asia/Pacific Region;ap-east-1
-AQ;Antarctica;af-south
-AR;Argentina;sa-east-1
-AS;American Samoa;ap-southeast-2
-AT;Austria;eu-south-1
-AU;Australia;ap-southeast-2
-AW;Aruba;us-east-1
-AX;Aland Islands;eu-west-1
-AZ;Azerbaijan;me-south-1
-BA;Bosnia and Herzegovina;eu-south-1
-BB;Barbados;us-east-1
-BD;Bangladesh;ap-south-1
-BE;Belgium;eu-west-3
-BF;Burkina Faso;eu-south-1
-BG;Bulgaria;eu-south-1
-BH;Bahrain;me-south-1
-BI;Burundi;af-south
-BJ;Benin;eu-south-1
-BL;Saint Barthélemy;us-east-1
-BM;Bermuda;us-east-1
-BN;Brunei Darussalam;ap-southeast-1
-BO;Bolivia;sa-east-1
-BQ;Caribbean Netherlands;us-east-1
-BR;Brazil;sa-east-1
-BS;Bahamas;us-east-1
-BT;Bhutan;ap-south-1
-BV;Bouvet Island;af-south
-BW;Botswana;eu-west-1
-BY;Belarus;eu-north-1
-BZ;Belize;us-east-1
-CA;Canada;us-west-2
-CC;Cocos (Keeling) Islands;ap-southeast-1
-CD;Congo, The Democratic Republic of the;af-south
-CF;Central African Republic;me-south-1
-CG;Congo;af-south
-CH;Switzerland;eu-south-1
-CI;Cote d'Ivoire;eu-south-1
-CK;Cook Islands;ap-southeast-2
-CL;Chile;sa-east-1
-CM;Cameroon;eu-south-1
-CN;China;ap-east-1
-CO;Colombia;sa-east-1
-CR;Costa Rica;us-east-1
-CU;Cuba;us-east-1
-CV;Cape Verde;eu-west-1
-CW;Curaçao;us-east-1
-CX;Christmas Island;ap-southeast-1
-CY;Cyprus;me-south-1
-CZ;Czech Republic;eu-central-1
-DE;Germany;eu-central-1
-DJ;Djibouti;me-south-1
-DK;Denmark;eu-north-1
-DM;Dominica;us-east-1
-DO;Dominican Republic;us-east-1
-DZ;Algeria;eu-south-1
-EC;Ecuador;sa-east-1
-EE;Estonia;eu-north-1
-EG;Egypt;me-south-1
-EH;Western Sahara;eu-west-3
-ER;Eritrea;me-south-1
-ES;Spain;eu-west-3
-ET;Ethiopia;me-south-1
-EU;Europe;eu-south-1
-FI;Finland;eu-north-1
-FJ;Fiji;ap-southeast-2
-FK;Falkland Islands (Malvinas);sa-east-1
-FM;Micronesia, Federated States of;ap-northeast-1
-FO;Faroe Islands;eu-west-1
-FR;France;eu-west-3
-GA;Gabon;af-south
-GB;United Kingdom;eu-west-2
-GD;Grenada;us-east-1
-GE;Georgia;me-south-1
-GF;French Guiana;sa-east-1
-GG;Guernsey;eu-west-1
-GH;Ghana;eu-south-1
-GI;Gibraltar;eu-west-3
-GL;Greenland;eu-west-1
-GM;Gambia;eu-west-3
-GN;Guinea;eu-south-1
-GP;Guadeloupe;us-east-1
-GQ;Equatorial Guinea;af-south
-GR;Greece;eu-south-1
-GS;South Georgia and the South Sandwich Islands;sa-east-1
-GT;Guatemala;us-east-1
-GU;Guam;ap-northeast-1
-GW;Guinea-Bissau;eu-south-1
-GY;Guyana;sa-east-1
-HK;Hong Kong;ap-east-1
-HM;Heard Island and McDonald Islands;af-south
-HN;Honduras;us-east-1
-HR;Croatia;eu-south-1
-HT;Haiti;us-east-1
-HU;Hungary;eu-south-1
-ID;Indonesia;ap-southeast-1
-IE;Ireland;eu-west-1
-IL;Israel;me-south-1
-IM;Isle of Man;eu-west-1
-IN;India;ap-south-1
-IO;British Indian Ocean Territory;ap-south-1
-IQ;Iraq;me-south-1
-IR;Iran, Islamic Republic of;me-south-1
-IS;Iceland;eu-west-1
-IT;Italy;eu-south-1
-JE;Jersey;eu-west-1
-JM;Jamaica;us-east-1
-JO;Jordan;me-south-1
-JP;Japan;ap-northeast-1
-KE;Kenya;me-south-1
-KG;Kyrgyzstan;ap-south-1
-KH;Cambodia;ap-southeast-1
-KI;Kiribati;ap-southeast-2
-KM;Comoros;af-south
-KN;Saint Kitts and Nevis;us-east-1
-KP;Korea, Democratic People's Republic of;ap-northeast-2
-KR;Korea, Republic of;ap-northeast-2
-KW;Kuwait;me-south-1
-KY;Cayman Islands;us-east-1
-KZ;Kazakhstan;me-south-1
-LA;Lao People's Democratic Republic;ap-east-1
-LB;Lebanon;me-south-1
-LC;Saint Lucia;us-east-1
-LI;Liechtenstein;eu-south-1
-LK;Sri Lanka;ap-south-1
-LR;Liberia;eu-south-1
-LS;Lesotho;ap-southeast-1
-LT;Lithuania;eu-north-1
-LU;Luxembourg;eu-central-1
-LV;Latvia;eu-north-1
-LY;Libyan Arab Jamahiriya;eu-south-1
-MA;Morocco;eu-south-1
-MC;Monaco;eu-south-1
-MD;Moldova, Republic of;eu-south-1
-ME;Montenegro;eu-south-1
-MF;Saint Martin;us-east-1
-MG;Madagascar;af-south
-MH;Marshall Islands;ap-northeast-1
-MK;Macedonia;eu-south-1
-ML;Mali;eu-south-1
-MM;Myanmar;ap-east-1
-MN;Mongolia;ap-northeast-2
-MO;Macao;ap-east-1
-MP;Northern Mariana Islands;ap-northeast-1
-MQ;Martinique;us-east-1
-MR;Mauritania;eu-south-1
-MS;Montserrat;us-east-1
-MT;Malta;eu-south-1
-MU;Mauritius;af-south
-MV;Maldives;ap-south-1
-MW;Malawi;af-south
-MX;Mexico;us-west-1
-MY;Malaysia;ap-southeast-1
-MZ;Mozambique;af-south
-NA;Namibia;eu-west-1
-NC;New Caledonia;ap-southeast-2
-NE;Niger;eu-south-1
-NF;Norfolk Island;ap-southeast-2
-NG;Nigeria;eu-south-1
-NI;Nicaragua;us-east-1
-NL;Netherlands;eu-west-1
-NO;Norway;eu-north-1
-NP;Nepal;ap-south-1
-NR;Nauru;ap-southeast-2
-NU;Niue;ap-southeast-2
-NZ;New Zealand;ap-southeast-2
-O1;Other Country;us-east-1
-OM;Oman;me-south-1
-PA;Panama;us-east-1
-PE;Peru;sa-east-1
-PF;French Polynesia;us-west-1
-PG;Papua New Guinea;ap-southeast-2
-PH;Philippines;ap-east-1
-PK;Pakistan;ap-south-1
-PL;Poland;eu-north-1
-PM;Saint Pierre and Miquelon;ca-central-1
-PN;Pitcairn;us-west-1
-PR;Puerto Rico;us-east-1
-PS;Palestinian Territory;me-south-1
-PT;Portugal;eu-west-3
-PW;Palau;ap-east-1
-PY;Paraguay;sa-east-1
-QA;Qatar;me-south-1
-RE;Reunion;af-south
-RO;Romania;eu-south-1
-RS;Serbia;eu-south-1
-RU;Russian Federation;ap-northeast-2
-RW;Rwanda;af-south
-SA;Saudi Arabia;me-south-1
-SB;Solomon Islands;ap-southeast-2
-SC;Seychelles;ap-south-1
-SD;Sudan;me-south-1
-SE;Sweden;eu-north-1
-SG;Singapore;ap-southeast-1
-SH;Saint Helena;af-south
-SI;Slovenia;eu-south-1
-SJ;Svalbard and Jan Mayen;eu-north-1
-SK;Slovakia;eu-central-1
-SL;Sierra Leone;eu-south-1
-SM;San Marino;eu-south-1
-SN;Senegal;eu-south-1
-SO;Somalia;me-south-1
-SR;Suriname;sa-east-1
-SS;South Sudan;me-south-1
-ST;Sao Tome and Principe;af-south
-SV;El Salvador;us-east-1
-SX;Sint Maarten;us-east-1
-SY;Syrian Arab Republic;me-south-1
-SZ;Swaziland;ap-southeast-1
-TC;Turks and Caicos Islands;us-east-1
-TD;Chad;me-south-1
-TF;French Southern Territories;af-south
-TG;Togo;eu-south-1
-TH;Thailand;ap-southeast-1
-TJ;Tajikistan;ap-south-1
-TK;Tokelau;ap-southeast-2
-TL;Timor-Leste;ap-southeast-1
-TM;Turkmenistan;me-south-1
-TN;Tunisia;eu-south-1
-TO;Tonga;ap-southeast-2
-TR;Turkey;me-south-1
-TT;Trinidad and Tobago;us-east-1
-TV;Tuvalu;ap-southeast-2
-TW;Taiwan;ap-east-1
-TZ;Tanzania, United Republic of;af-south
-UA;Ukraine;eu-north-1
-UG;Uganda;me-south-1
-UM;United States Minor Outlying Islands;ap-northeast-1
-US;United States;us-east-2
-UY;Uruguay;sa-east-1
-UZ;Uzbekistan;me-south-1
-VA;Holy See (Vatican City State);eu-south-1
-VC;Saint Vincent and the Grenadines;us-east-1
-VE;Venezuela;sa-east-1
-VG;Virgin Islands, British;us-east-1
-VI;Virgin Islands, U.S.;us-east-1
-VN;Vietnam;ap-east-1
-VU;Vanuatu;ap-southeast-2
-WF;Wallis and Futuna;ap-southeast-2
-WS;Samoa;ap-southeast-2
-XK;Kosovo;eu-south-1
-YE;Yemen;me-south-1
-YT;Mayotte;af-south
-ZA;South Africa;ap-southeast-1
-ZM;Zambia;eu-west-1
-ZW;Zimbabwe;eu-west-1
+A1;Anonymous Proxy;us-east-1;None
+A2;Satellite Provider;us-east-1;None
+AD;Andorra;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,af-south-1,us-west-2,sa-east-1,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+AE;United Arab Emirates;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,ap-southeast-1,eu-west-1,ap-east-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,sa-east-1,ap-southeast-2,us-west-2,us-west-1
+AF;Afghanistan;me-south-1;me-south-1,ap-south-1,eu-north-1,eu-south-1,ap-east-1,eu-central-1,ap-southeast-1,eu-west-3,eu-west-2,ap-northeast-2,eu-west-1,ap-northeast-3,ap-northeast-1,af-south-1,ca-central-1,us-west-2,us-east-1,us-east-2,ap-southeast-2,us-west-1,sa-east-1
+AG;Antigua and Barbuda;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+AI;Anguilla;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,eu-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+AL;Albania;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,af-south-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-southeast-1,ap-northeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+AM;Armenia;me-south-1;me-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,ap-south-1,eu-west-2,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-1,ap-northeast-3,ap-northeast-1,af-south-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,sa-east-1,ap-southeast-2
+AN;Netherlands Antilles;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+AO;Angola;eu-west-1;af-south-1,me-south-1,eu-south-1,ap-south-1,sa-east-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,ap-southeast-1,ap-east-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-southeast-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1
+AP;Asia/Pacific Region;ap-east-1;ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-south-1,ap-southeast-1,me-south-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-2,us-west-2,us-west-1,ca-central-1,us-east-2,af-south-1,us-east-1,sa-east-1
+AQ;Antarctica;af-south-1;af-south-1,ap-southeast-2,sa-east-1,ap-southeast-1,ap-south-1,ap-east-1,me-south-1,ap-northeast-3,ap-northeast-1,us-west-1,ap-northeast-2,us-east-1,us-east-2,eu-south-1,ca-central-1,us-west-2,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1
+AR;Argentina;sa-east-1;sa-east-1,af-south-1,us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-3,eu-west-2,eu-south-1,ap-southeast-2,eu-central-1,eu-north-1,me-south-1,ap-south-1,ap-southeast-1,ap-northeast-1,ap-northeast-3,ap-east-1,ap-northeast-2
+AS;American Samoa;ap-southeast-2;ap-southeast-2,us-west-1,ap-northeast-1,ap-northeast-3,us-west-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,sa-east-1,ap-south-1,af-south-1,eu-north-1,eu-west-1,me-south-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+AT;Austria;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,us-west-2,ap-east-1,af-south-1,ap-northeast-3,ap-northeast-1,us-west-1,sa-east-1,ap-southeast-1,ap-southeast-2
+AU;Australia;ap-southeast-2;ap-southeast-2,ap-southeast-1,ap-east-1,ap-northeast-3,ap-northeast-1,ap-northeast-2,ap-south-1,af-south-1,me-south-1,us-west-1,us-west-2,eu-north-1,sa-east-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,us-east-2,us-east-1,ca-central-1
+AW;Aruba;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+AX;Aland Islands;eu-west-1;None
+AZ;Azerbaijan;me-south-1;me-south-1,eu-north-1,eu-south-1,eu-central-1,ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-1,ap-northeast-3,ap-northeast-1,af-south-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,sa-east-1,ap-southeast-2
+BA;Bosnia and Herzegovina;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,af-south-1,ap-east-1,ap-northeast-3,us-west-2,ap-northeast-1,ap-southeast-1,sa-east-1,us-west-1,ap-southeast-2
+BB;Barbados;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,eu-west-2,eu-west-3,us-west-2,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+BD;Bangladesh;ap-south-1;ap-south-1,ap-east-1,ap-southeast-1,ap-northeast-2,me-south-1,ap-northeast-3,ap-northeast-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-2,af-south-1,us-west-2,ca-central-1,us-west-1,us-east-2,us-east-1,sa-east-1
+BE;Belgium;eu-west-3;eu-west-3,eu-west-2,eu-central-1,eu-south-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,ap-northeast-2,us-west-1,ap-northeast-3,ap-east-1,ap-northeast-1,af-south-1,sa-east-1,ap-southeast-1,ap-southeast-2
+BF;Burkina Faso;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,me-south-1,af-south-1,sa-east-1,ca-central-1,us-east-1,ap-south-1,us-east-2,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+BG;Bulgaria;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,us-east-1,ap-east-1,us-east-2,af-south-1,ap-northeast-3,ap-southeast-1,ap-northeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+BH;Bahrain;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,sa-east-1,us-west-2,ap-southeast-2,us-west-1
+BI;Burundi;af-south-1;af-south-1,me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-southeast-1,sa-east-1,ap-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+BJ;Benin;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,af-south-1,me-south-1,eu-north-1,sa-east-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,us-west-2,us-west-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+BL;Saint Barthélemy;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,eu-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+BM;Bermuda;us-east-1;us-east-1,ca-central-1,us-east-2,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,sa-east-1,eu-north-1,me-south-1,af-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+BN;Brunei Darussalam;ap-southeast-1;ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-south-1,ap-southeast-2,me-south-1,eu-north-1,eu-central-1,eu-south-1,af-south-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+BO;Bolivia;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,af-south-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-south-1,eu-central-1,eu-north-1,ap-southeast-2,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-southeast-1,ap-east-1
+BQ;Caribbean Netherlands;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+BR;Brazil;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,af-south-1,eu-west-1,eu-west-2,eu-west-3,us-west-1,eu-south-1,eu-central-1,us-west-2,eu-north-1,me-south-1,ap-south-1,ap-southeast-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-1,ap-east-1
+BS;Bahamas;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+BT;Bhutan;ap-south-1;ap-south-1,ap-east-1,ap-southeast-1,ap-northeast-2,me-south-1,ap-northeast-3,ap-northeast-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-2,af-south-1,us-west-2,ca-central-1,us-west-1,us-east-2,us-east-1,sa-east-1
+BV;Bouvet Island;af-south-1;af-south-1,sa-east-1,ap-southeast-2,me-south-1,ap-south-1,ap-southeast-1,eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,us-east-1,ca-central-1,us-east-2,ap-east-1,ap-northeast-2,us-west-1,ap-northeast-3,ap-northeast-1,us-west-2
+BW;Botswana;eu-west-1;af-south-1,me-south-1,ap-south-1,sa-east-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-1,eu-north-1,ap-east-1,ap-southeast-2,ca-central-1,us-east-1,ap-northeast-2,us-east-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1
+BY;Belarus;eu-north-1;eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-east-1,ap-northeast-3,ap-northeast-1,us-west-2,ap-southeast-1,us-west-1,af-south-1,sa-east-1,ap-southeast-2
+BZ;Belize;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,ap-northeast-1,ap-northeast-3,af-south-1,ap-northeast-2,me-south-1,ap-southeast-2,ap-east-1,ap-south-1,ap-southeast-1
+CA;Canada;us-west-2;us-west-2,ca-central-1,us-east-2,us-west-1,us-east-1,eu-west-1,eu-north-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,sa-east-1,ap-south-1,ap-southeast-1,ap-southeast-2,af-south-1
+CC;Cocos (Keeling) Islands;ap-southeast-1;ap-southeast-1,ap-east-1,ap-south-1,ap-southeast-2,ap-northeast-2,me-south-1,ap-northeast-3,ap-northeast-1,af-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,sa-east-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1
+CD;Congo, The Democratic Republic of the;af-south-1;af-south-1,me-south-1,eu-south-1,ap-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,sa-east-1,ap-southeast-1,ap-east-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-northeast-3,ap-northeast-1,ap-southeast-2,us-west-2,us-west-1
+CF;Central African Republic;me-south-1;me-south-1,eu-south-1,af-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-south-1,eu-north-1,sa-east-1,ap-southeast-1,ca-central-1,ap-east-1,us-east-1,us-east-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1,ap-southeast-2
+CG;Congo;af-south-1;af-south-1,me-south-1,eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,ap-south-1,eu-north-1,sa-east-1,ap-southeast-1,ca-central-1,us-east-1,us-east-2,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,us-west-2,ap-southeast-2,us-west-1
+CH;Switzerland;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,us-west-2,ap-northeast-2,af-south-1,ap-east-1,us-west-1,sa-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+CI;Cote d'Ivoire;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,af-south-1,sa-east-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+CK;Cook Islands;ap-southeast-2;ap-southeast-2,us-west-1,us-west-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,us-east-2,ap-east-1,us-east-1,ap-southeast-1,sa-east-1,ca-central-1,af-south-1,ap-south-1,eu-west-1,eu-north-1,eu-west-2,eu-west-3,eu-central-1,me-south-1,eu-south-1
+CL;Chile;sa-east-1;sa-east-1,us-east-1,us-east-2,af-south-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-south-1,ap-southeast-2,eu-central-1,eu-north-1,me-south-1,ap-south-1,ap-southeast-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1
+CM;Cameroon;eu-south-1;eu-south-1,af-south-1,me-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,ap-south-1,sa-east-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,us-west-2,ap-northeast-1,us-west-1,ap-southeast-2
+CN;China;ap-east-1;ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-south-1,ap-southeast-1,me-south-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-2,us-west-2,us-west-1,ca-central-1,us-east-2,af-south-1,us-east-1,sa-east-1
+CO;Colombia;sa-east-1;us-east-1,sa-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-1
+CR;Costa Rica;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,ap-northeast-3,me-south-1,ap-northeast-2,ap-southeast-2,ap-south-1,ap-east-1,ap-southeast-1
+CU;Cuba;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,me-south-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+CV;Cape Verde;eu-west-1;eu-west-1,eu-west-3,eu-west-2,eu-south-1,eu-central-1,sa-east-1,ca-central-1,us-east-1,eu-north-1,us-east-2,af-south-1,me-south-1,us-west-2,us-west-1,ap-south-1,ap-northeast-2,ap-east-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+CW;Curaçao;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+CX;Christmas Island;ap-southeast-1;ap-southeast-1,ap-east-1,ap-south-1,ap-southeast-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,me-south-1,af-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,sa-east-1,ca-central-1,us-east-2,us-east-1
+CY;Cyprus;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,ap-south-1,af-south-1,ap-east-1,ap-northeast-2,ap-southeast-1,ca-central-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+CZ;Czech Republic;eu-central-1;eu-central-1,eu-south-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,us-west-2,ap-east-1,ap-northeast-3,ap-northeast-1,af-south-1,us-west-1,ap-southeast-1,sa-east-1,ap-southeast-2
+DE;Germany;eu-central-1;eu-central-1,eu-west-3,eu-south-1,eu-west-2,eu-north-1,eu-west-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,us-west-2,ap-northeast-2,us-west-1,ap-east-1,ap-northeast-3,ap-northeast-1,af-south-1,sa-east-1,ap-southeast-1,ap-southeast-2
+DJ;Djibouti;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,af-south-1,eu-north-1,eu-west-2,eu-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,sa-east-1,ca-central-1,us-east-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+DK;Denmark;eu-north-1;eu-north-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1,eu-west-1,me-south-1,ca-central-1,us-east-1,ap-south-1,us-east-2,us-west-2,ap-northeast-2,us-west-1,ap-northeast-3,ap-northeast-1,ap-east-1,af-south-1,ap-southeast-1,sa-east-1,ap-southeast-2
+DM;Dominica;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+DO;Dominican Republic;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,sa-east-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+DZ;Algeria;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,me-south-1,ca-central-1,af-south-1,ap-south-1,us-east-1,us-east-2,sa-east-1,us-west-2,ap-northeast-2,ap-east-1,us-west-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+EC;Ecuador;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,af-south-1,eu-north-1,ap-southeast-2,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-1
+EE;Estonia;eu-north-1;eu-north-1,eu-central-1,eu-west-2,eu-south-1,eu-west-3,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-northeast-3,ap-east-1,ap-northeast-1,us-west-2,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+EG;Egypt;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-south-1,af-south-1,ap-southeast-1,ap-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,us-east-2,ap-northeast-1,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+EH;Western Sahara;eu-west-3;eu-west-3,eu-south-1,eu-west-2,eu-west-1,eu-central-1,eu-north-1,ca-central-1,us-east-1,me-south-1,sa-east-1,us-east-2,af-south-1,ap-south-1,us-west-2,us-west-1,ap-northeast-2,ap-east-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+ER;Eritrea;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,af-south-1,eu-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,sa-east-1,ca-central-1,us-east-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+ES;Spain;eu-west-3;eu-west-3,eu-south-1,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,sa-east-1,af-south-1,us-west-2,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+ET;Ethiopia;me-south-1;me-south-1,ap-south-1,eu-south-1,af-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,sa-east-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+EU;Europe;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,us-west-2,ap-northeast-2,af-south-1,ap-east-1,us-west-1,sa-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+FI;Finland;eu-north-1;eu-north-1,eu-central-1,eu-west-2,eu-west-3,eu-west-1,eu-south-1,me-south-1,ca-central-1,ap-south-1,ap-northeast-2,us-east-1,us-east-2,ap-northeast-3,us-west-2,ap-northeast-1,ap-east-1,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+FJ;Fiji;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-1,us-west-2,ap-south-1,us-east-2,us-east-1,ca-central-1,sa-east-1,af-south-1,me-south-1,eu-north-1,eu-west-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1
+FK;Falkland Islands (Malvinas);sa-east-1;sa-east-1,af-south-1,ap-southeast-2,us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-3,eu-south-1,eu-west-2,eu-central-1,me-south-1,eu-north-1,ap-southeast-1,ap-south-1,ap-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2
+FM;Micronesia, Federated States of;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-southeast-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-2,us-west-1,ap-south-1,me-south-1,eu-north-1,us-east-2,ca-central-1,us-east-1,eu-central-1,eu-west-1,eu-west-2,eu-west-3,eu-south-1,af-south-1,sa-east-1
+FO;Faroe Islands;eu-west-1;eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ca-central-1,us-east-1,us-east-2,me-south-1,us-west-2,us-west-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-east-1,sa-east-1,af-south-1,ap-southeast-1,ap-southeast-2
+FR;France;eu-west-3;eu-west-3,eu-south-1,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,af-south-1,sa-east-1,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+GA;Gabon;af-south-1;af-south-1,me-south-1,eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,sa-east-1,ap-south-1,ca-central-1,us-east-1,ap-southeast-1,us-east-2,ap-east-1,ap-northeast-2,ap-northeast-3,us-west-2,ap-northeast-1,us-west-1,ap-southeast-2
+GB;United Kingdom;eu-west-2;eu-west-2,eu-west-1,eu-west-3,eu-central-1,eu-south-1,eu-north-1,ca-central-1,me-south-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-east-1,sa-east-1,af-south-1,ap-southeast-1,ap-southeast-2
+GD;Grenada;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+GE;Georgia;me-south-1;me-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,ap-south-1,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-1,ap-northeast-3,ap-northeast-1,ca-central-1,af-south-1,us-east-1,us-east-2,us-west-2,us-west-1,sa-east-1,ap-southeast-2
+GF;French Guiana;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,eu-west-1,eu-west-2,eu-west-3,eu-south-1,eu-central-1,us-west-1,us-west-2,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-2,ap-northeast-1,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+GG;Guernsey;eu-west-1;None
+GH;Ghana;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,af-south-1,me-south-1,eu-north-1,sa-east-1,ca-central-1,ap-south-1,us-east-1,us-east-2,us-west-2,ap-southeast-1,us-west-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+GI;Gibraltar;eu-west-3;eu-west-3,eu-south-1,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,sa-east-1,af-south-1,us-west-2,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+GL;Greenland;eu-west-1;eu-west-1,eu-north-1,eu-west-2,eu-west-3,eu-central-1,ca-central-1,eu-south-1,us-east-2,us-east-1,us-west-2,us-west-1,me-south-1,ap-northeast-2,ap-northeast-1,ap-northeast-3,ap-south-1,ap-east-1,sa-east-1,ap-southeast-1,af-south-1,ap-southeast-2
+GM;Gambia;eu-west-3;eu-west-3,eu-south-1,eu-west-2,eu-west-1,eu-central-1,sa-east-1,eu-north-1,ca-central-1,af-south-1,us-east-1,us-east-2,me-south-1,ap-south-1,us-west-2,us-west-1,ap-northeast-2,ap-southeast-1,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+GN;Guinea;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,sa-east-1,af-south-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+GP;Guadeloupe;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+GQ;Equatorial Guinea;af-south-1;af-south-1,eu-south-1,me-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,sa-east-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,us-west-2,ap-northeast-3,ap-northeast-1,us-west-1,ap-southeast-2
+GR;Greece;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,af-south-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+GS;South Georgia and the South Sandwich Islands;sa-east-1;sa-east-1,af-south-1,ap-southeast-2,us-east-1,us-east-2,ca-central-1,eu-south-1,eu-west-3,me-south-1,eu-west-2,eu-west-1,eu-central-1,ap-south-1,us-west-1,ap-southeast-1,eu-north-1,us-west-2,ap-east-1,ap-northeast-3,ap-northeast-2,ap-northeast-1
+GT;Guatemala;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,ap-northeast-1,ap-northeast-3,af-south-1,ap-northeast-2,ap-southeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-1
+GU;Guam;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,ap-southeast-2,ap-south-1,us-west-2,us-west-1,me-south-1,eu-north-1,eu-central-1,eu-west-2,eu-south-1,eu-west-3,eu-west-1,us-east-2,ca-central-1,us-east-1,af-south-1,sa-east-1
+GW;Guinea-Bissau;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-west-1,eu-central-1,sa-east-1,eu-north-1,af-south-1,ca-central-1,us-east-1,me-south-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+GY;Guyana;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,eu-west-1,us-west-1,eu-west-2,eu-west-3,us-west-2,eu-south-1,eu-central-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+HK;Hong Kong;ap-east-1;ap-east-1,ap-northeast-2,ap-northeast-3,ap-southeast-1,ap-northeast-1,ap-south-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,af-south-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+HM;Heard Island and McDonald Islands;af-south-1;af-south-1,ap-southeast-2,ap-southeast-1,ap-south-1,me-south-1,ap-east-1,sa-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,us-east-1,ca-central-1,us-east-2,us-west-1,us-west-2
+HN;Honduras;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-southeast-2,ap-east-1,ap-south-1,ap-southeast-1
+HR;Croatia;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,af-south-1,ap-east-1,us-west-2,ap-northeast-3,ap-northeast-1,ap-southeast-1,sa-east-1,us-west-1,ap-southeast-2
+HT;Haiti;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,sa-east-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+HU;Hungary;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,ap-northeast-3,af-south-1,ap-northeast-1,us-west-2,ap-southeast-1,us-west-1,sa-east-1,ap-southeast-2
+ID;Indonesia;ap-southeast-1;ap-southeast-1,ap-east-1,ap-southeast-2,ap-northeast-3,ap-northeast-2,ap-northeast-1,ap-south-1,me-south-1,af-south-1,eu-north-1,eu-central-1,eu-south-1,us-west-2,eu-west-3,eu-west-2,us-west-1,eu-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+IE;Ireland;eu-west-1;eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,ca-central-1,us-east-1,me-south-1,us-east-2,us-west-2,ap-south-1,us-west-1,ap-northeast-2,sa-east-1,ap-northeast-3,ap-northeast-1,ap-east-1,af-south-1,ap-southeast-1,ap-southeast-2
+IL;Israel;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,ap-south-1,eu-west-1,af-south-1,ap-east-1,ap-southeast-1,ap-northeast-2,ca-central-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+IM;Isle of Man;eu-west-1;None
+IN;India;ap-south-1;ap-south-1,me-south-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,ap-southeast-2,ca-central-1,us-west-2,us-east-2,us-east-1,us-west-1,sa-east-1
+IO;British Indian Ocean Territory;ap-south-1;ap-south-1,ap-southeast-1,me-south-1,ap-east-1,af-south-1,ap-northeast-2,ap-northeast-3,eu-south-1,ap-northeast-1,eu-north-1,ap-southeast-2,eu-central-1,eu-west-3,eu-west-2,eu-west-1,sa-east-1,ca-central-1,us-west-2,us-east-1,us-east-2,us-west-1
+IQ;Iraq;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,ap-east-1,ap-southeast-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+IR;Iran, Islamic Republic of;me-south-1;me-south-1,ap-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-east-1,ap-southeast-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,af-south-1,ca-central-1,us-east-1,us-east-2,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+IS;Iceland;eu-west-1;eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ca-central-1,us-east-1,us-east-2,us-west-2,me-south-1,us-west-1,ap-south-1,ap-northeast-2,ap-northeast-1,ap-northeast-3,ap-east-1,sa-east-1,ap-southeast-1,af-south-1,ap-southeast-2
+IT;Italy;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,af-south-1,ap-northeast-2,ap-east-1,us-west-2,sa-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,us-west-1,ap-southeast-2
+JE;Jersey;eu-west-1;None
+JM;Jamaica;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-southeast-2,ap-east-1,ap-southeast-1
+JO;Jordan;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,ap-south-1,eu-west-1,af-south-1,ap-east-1,ap-southeast-1,ap-northeast-2,ap-northeast-3,ca-central-1,ap-northeast-1,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+JP;Japan;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,ap-south-1,us-west-2,ap-southeast-2,eu-north-1,me-south-1,us-west-1,eu-central-1,eu-west-2,eu-west-1,eu-south-1,eu-west-3,ca-central-1,us-east-2,us-east-1,af-south-1,sa-east-1
+KE;Kenya;me-south-1;me-south-1,ap-south-1,af-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-southeast-1,ap-east-1,sa-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,ap-southeast-2,us-east-1,us-east-2,us-west-2,us-west-1
+KG;Kyrgyzstan;ap-south-1;ap-south-1,me-south-1,ap-east-1,eu-north-1,ap-northeast-2,eu-central-1,eu-south-1,ap-northeast-3,ap-southeast-1,ap-northeast-1,eu-west-3,eu-west-2,eu-west-1,ca-central-1,af-south-1,us-west-2,us-east-2,us-east-1,us-west-1,ap-southeast-2,sa-east-1
+KH;Cambodia;ap-southeast-1;ap-southeast-1,ap-east-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+KI;Kiribati;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-1,us-west-2,ap-south-1,us-east-2,us-east-1,ca-central-1,eu-north-1,me-south-1,eu-west-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1,sa-east-1,af-south-1
+KM;Comoros;af-south-1;af-south-1,me-south-1,ap-south-1,ap-southeast-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,ap-east-1,eu-west-1,sa-east-1,ap-northeast-2,ap-southeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+KN;Saint Kitts and Nevis;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+KP;Korea, Democratic People's Republic of;ap-northeast-2;ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-east-1,ap-southeast-1,ap-south-1,me-south-1,eu-north-1,us-west-2,eu-central-1,ap-southeast-2,eu-west-2,eu-south-1,eu-west-3,eu-west-1,us-west-1,ca-central-1,us-east-2,us-east-1,af-south-1,sa-east-1
+KR;Korea, Republic of;ap-northeast-2;ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-east-1,ap-southeast-1,ap-south-1,me-south-1,eu-north-1,ap-southeast-2,us-west-2,eu-central-1,eu-south-1,eu-west-2,eu-west-3,us-west-1,eu-west-1,ca-central-1,us-east-2,us-east-1,af-south-1,sa-east-1
+KW;Kuwait;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-east-1,ap-southeast-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+KY;Cayman Islands;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,me-south-1,ap-northeast-3,ap-northeast-2,ap-southeast-2,ap-south-1,ap-east-1,ap-southeast-1
+KZ;Kazakhstan;me-south-1;me-south-1,ap-south-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,ap-northeast-2,ap-east-1,eu-west-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ca-central-1,us-west-2,us-east-2,us-east-1,af-south-1,us-west-1,ap-southeast-2,sa-east-1
+LA;Lao People's Democratic Republic;ap-east-1;ap-east-1,ap-southeast-1,ap-northeast-2,ap-south-1,ap-northeast-3,ap-northeast-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+LB;Lebanon;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,ap-south-1,eu-west-1,ap-east-1,af-south-1,ap-northeast-2,ap-southeast-1,ca-central-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+LC;Saint Lucia;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,eu-west-2,us-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+LI;Liechtenstein;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,us-west-2,ap-northeast-2,af-south-1,ap-east-1,ap-northeast-3,us-west-1,ap-northeast-1,sa-east-1,ap-southeast-1,ap-southeast-2
+LK;Sri Lanka;ap-south-1;ap-south-1,ap-southeast-1,me-south-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,eu-north-1,af-south-1,eu-south-1,eu-central-1,eu-west-3,ap-southeast-2,eu-west-2,eu-west-1,us-west-2,ca-central-1,sa-east-1,us-west-1,us-east-2,us-east-1
+LR;Liberia;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,sa-east-1,af-south-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+LS;Lesotho;ap-southeast-1;af-south-1,me-south-1,ap-south-1,sa-east-1,eu-south-1,ap-southeast-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,ap-southeast-2,ap-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,us-west-2,us-west-1
+LT;Lithuania;eu-north-1;eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+LU;Luxembourg;eu-central-1;eu-central-1,eu-west-3,eu-west-2,eu-south-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,ap-northeast-2,us-west-1,ap-east-1,af-south-1,ap-northeast-3,ap-northeast-1,sa-east-1,ap-southeast-1,ap-southeast-2
+LV;Latvia;eu-north-1;eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-east-1,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+LY;Libyan Arab Jamahiriya;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,me-south-1,eu-west-1,eu-north-1,ap-south-1,af-south-1,ca-central-1,sa-east-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1,ap-southeast-2
+MA;Morocco;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,sa-east-1,af-south-1,ap-south-1,us-west-2,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+MC;Monaco;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,af-south-1,us-west-2,ap-northeast-2,sa-east-1,ap-east-1,us-west-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+MD;Moldova, Republic of;eu-south-1;eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,ap-east-1,us-east-1,us-east-2,ap-northeast-3,ap-northeast-1,ap-southeast-1,af-south-1,us-west-2,us-west-1,sa-east-1,ap-southeast-2
+ME;Montenegro;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,af-south-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-southeast-1,ap-northeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+MF;Saint Martin;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,eu-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+MG;Madagascar;af-south-1;af-south-1,me-south-1,ap-south-1,ap-southeast-1,eu-south-1,ap-east-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,sa-east-1,eu-west-1,ap-southeast-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+MH;Marshall Islands;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-southeast-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-2,us-west-1,ap-south-1,us-east-2,us-east-1,ca-central-1,eu-north-1,me-south-1,eu-west-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1,af-south-1,sa-east-1
+MK;Macedonia;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,af-south-1,ap-east-1,ap-northeast-3,ap-southeast-1,ap-northeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+ML;Mali;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,eu-north-1,me-south-1,af-south-1,sa-east-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+MM;Myanmar;ap-east-1;ap-east-1,ap-southeast-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,me-south-1,eu-north-1,eu-central-1,eu-south-1,ap-southeast-2,eu-west-3,eu-west-2,eu-west-1,af-south-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+MN;Mongolia;ap-northeast-2;ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-south-1,ap-southeast-1,me-south-1,eu-north-1,eu-central-1,eu-south-1,eu-west-2,eu-west-3,eu-west-1,us-west-2,us-west-1,ca-central-1,ap-southeast-2,us-east-2,us-east-1,af-south-1,sa-east-1
+MO;Macao;ap-east-1;ap-east-1,ap-northeast-2,ap-southeast-1,ap-northeast-3,ap-northeast-1,ap-south-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,af-south-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+MP;Northern Mariana Islands;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,ap-southeast-2,ap-south-1,us-west-2,us-west-1,me-south-1,eu-north-1,eu-central-1,eu-west-2,eu-south-1,eu-west-1,eu-west-3,us-east-2,ca-central-1,us-east-1,af-south-1,sa-east-1
+MQ;Martinique;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,eu-west-2,us-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+MR;Mauritania;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-west-1,eu-central-1,eu-north-1,sa-east-1,ca-central-1,me-south-1,us-east-1,af-south-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-northeast-2,ap-east-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+MS;Montserrat;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+MT;Malta;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,me-south-1,ap-south-1,ca-central-1,af-south-1,us-east-1,us-east-2,sa-east-1,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-2,ap-northeast-3,ap-northeast-1,us-west-1,ap-southeast-2
+MU;Mauritius;af-south-1;af-south-1,ap-south-1,me-south-1,ap-southeast-1,ap-east-1,eu-south-1,ap-southeast-2,eu-central-1,eu-west-3,eu-north-1,ap-northeast-2,eu-west-2,ap-northeast-3,eu-west-1,sa-east-1,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+MV;Maldives;ap-south-1;ap-south-1,ap-southeast-1,me-south-1,ap-east-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-2,sa-east-1,ca-central-1,us-west-2,us-east-1,us-east-2,us-west-1
+MW;Malawi;af-south-1;af-south-1,me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,ap-southeast-1,eu-west-2,eu-north-1,eu-west-1,sa-east-1,ap-east-1,ap-northeast-2,ap-southeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+MX;Mexico;us-west-1;us-west-1,us-east-2,us-east-1,us-west-2,ca-central-1,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-southeast-2,ap-east-1,me-south-1,af-south-1,ap-south-1,ap-southeast-1
+MY;Malaysia;ap-southeast-1;ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-south-1,ap-southeast-2,me-south-1,eu-north-1,af-south-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+MZ;Mozambique;af-south-1;af-south-1,me-south-1,ap-south-1,eu-south-1,ap-southeast-1,eu-central-1,eu-west-3,sa-east-1,eu-west-2,eu-north-1,eu-west-1,ap-east-1,ap-southeast-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+NA;Namibia;eu-west-1;af-south-1,sa-east-1,me-south-1,eu-south-1,ap-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,ap-southeast-1,ap-east-1,ca-central-1,us-east-1,ap-southeast-2,us-east-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1
+NC;New Caledonia;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-southeast-1,ap-east-1,ap-northeast-2,us-west-1,us-west-2,ap-south-1,af-south-1,us-east-2,me-south-1,us-east-1,sa-east-1,ca-central-1,eu-north-1,eu-central-1,eu-west-1,eu-west-2,eu-south-1,eu-west-3
+NE;Niger;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,me-south-1,eu-north-1,af-south-1,ap-south-1,sa-east-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,us-west-2,us-west-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+NF;Norfolk Island;ap-southeast-2;ap-southeast-2,ap-southeast-1,ap-northeast-1,ap-northeast-3,ap-east-1,ap-northeast-2,us-west-1,us-west-2,ap-south-1,af-south-1,sa-east-1,us-east-2,us-east-1,me-south-1,ca-central-1,eu-north-1,eu-central-1,eu-west-1,eu-west-2,eu-south-1,eu-west-3
+NG;Nigeria;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,me-south-1,eu-west-1,af-south-1,eu-north-1,sa-east-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,us-west-2,ap-northeast-3,us-west-1,ap-northeast-1,ap-southeast-2
+NI;Nicaragua;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-southeast-2,ap-east-1,ap-south-1,ap-southeast-1
+NL;Netherlands;eu-west-1;eu-central-1,eu-west-2,eu-west-3,eu-south-1,eu-west-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,ap-northeast-2,us-west-1,ap-northeast-3,ap-east-1,ap-northeast-1,af-south-1,sa-east-1,ap-southeast-1,ap-southeast-2
+NO;Norway;eu-north-1;eu-north-1,eu-central-1,eu-west-2,eu-west-1,eu-west-3,eu-south-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,ap-northeast-2,us-west-1,ap-northeast-3,ap-northeast-1,ap-east-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+NP;Nepal;ap-south-1;ap-south-1,ap-east-1,me-south-1,ap-southeast-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,ap-southeast-2,us-west-2,ca-central-1,us-west-1,us-east-2,us-east-1,sa-east-1
+NR;Nauru;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,us-west-1,us-west-2,ap-south-1,us-east-2,us-east-1,ca-central-1,me-south-1,eu-north-1,eu-west-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1,af-south-1,sa-east-1
+NU;Niue;ap-southeast-2;ap-southeast-2,us-west-1,ap-northeast-1,ap-northeast-3,us-west-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,sa-east-1,ap-south-1,af-south-1,eu-north-1,me-south-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+NZ;New Zealand;ap-southeast-2;ap-southeast-2,ap-southeast-1,ap-northeast-1,ap-northeast-3,ap-east-1,ap-northeast-2,us-west-1,af-south-1,us-west-2,sa-east-1,ap-south-1,us-east-2,us-east-1,me-south-1,ca-central-1,eu-north-1,eu-central-1,eu-west-1,eu-south-1,eu-west-2,eu-west-3
+O1;Other Country;us-east-1;None
+OM;Oman;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-north-1,eu-central-1,ap-southeast-1,eu-west-3,ap-east-1,eu-west-2,eu-west-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,ap-southeast-2,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1
+PA;Panama;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-southeast-2,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-1
+PE;Peru;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,af-south-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,ap-southeast-2,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-1
+PF;French Polynesia;us-west-1;us-west-1,us-west-2,ap-southeast-2,us-east-2,us-east-1,ca-central-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-1,eu-west-1,af-south-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ap-south-1,me-south-1
+PG;Papua New Guinea;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-east-1,ap-southeast-1,ap-northeast-2,ap-south-1,us-west-2,us-west-1,me-south-1,eu-north-1,af-south-1,us-east-2,eu-central-1,eu-south-1,ca-central-1,eu-west-2,eu-west-3,us-east-1,eu-west-1,sa-east-1
+PH;Philippines;ap-east-1;ap-east-1,ap-southeast-1,ap-northeast-3,ap-northeast-2,ap-northeast-1,ap-south-1,ap-southeast-2,me-south-1,eu-north-1,eu-central-1,eu-south-1,us-west-2,eu-west-3,eu-west-2,eu-west-1,us-west-1,af-south-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+PK;Pakistan;ap-south-1;ap-south-1,me-south-1,ap-east-1,ap-southeast-1,eu-north-1,ap-northeast-2,eu-south-1,eu-central-1,eu-west-3,ap-northeast-3,eu-west-2,ap-northeast-1,eu-west-1,af-south-1,ca-central-1,ap-southeast-2,us-west-2,us-east-2,us-east-1,us-west-1,sa-east-1
+PL;Poland;eu-north-1;eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,ap-northeast-3,us-west-2,ap-northeast-1,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+PM;Saint Pierre and Miquelon;ca-central-1;ca-central-1,us-east-1,us-east-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,us-west-2,us-west-1,sa-east-1,me-south-1,ap-northeast-2,ap-northeast-1,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+PN;Pitcairn;us-west-1;None
+PR;Puerto Rico;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+PS;Palestinian Territory;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,ap-south-1,eu-west-1,af-south-1,ap-east-1,ap-southeast-1,ap-northeast-2,ca-central-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,sa-east-1,us-west-2,us-west-1,ap-southeast-2
+PT;Portugal;eu-west-3;eu-west-3,eu-west-2,eu-west-1,eu-south-1,eu-central-1,eu-north-1,ca-central-1,me-south-1,us-east-1,us-east-2,ap-south-1,sa-east-1,us-west-2,af-south-1,us-west-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-southeast-2
+PW;Palau;ap-east-1;ap-east-1,ap-northeast-3,ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-2,ap-south-1,me-south-1,us-west-2,us-west-1,eu-north-1,eu-central-1,eu-south-1,eu-west-2,eu-west-3,eu-west-1,af-south-1,us-east-2,ca-central-1,us-east-1,sa-east-1
+PY;Paraguay;sa-east-1;sa-east-1,us-east-1,af-south-1,us-east-2,ca-central-1,us-west-1,eu-west-1,eu-west-3,eu-west-2,us-west-2,eu-south-1,eu-central-1,eu-north-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1
+QA;Qatar;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-north-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,sa-east-1,us-west-2,ap-southeast-2,us-west-1
+RE;Reunion;af-south-1;af-south-1,ap-south-1,me-south-1,ap-southeast-1,ap-east-1,eu-south-1,eu-central-1,ap-southeast-2,eu-west-3,eu-north-1,eu-west-2,ap-northeast-2,sa-east-1,eu-west-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+RO;Romania;eu-south-1;eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-east-1,ap-northeast-3,ap-northeast-1,af-south-1,ap-southeast-1,us-west-2,us-west-1,sa-east-1,ap-southeast-2
+RS;Serbia;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,af-south-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+RU;Russian Federation;ap-northeast-2;ap-northeast-2,ap-northeast-3,ap-northeast-1,eu-north-1,ap-east-1,ap-south-1,me-south-1,eu-central-1,eu-west-2,eu-south-1,eu-west-3,eu-west-1,ap-southeast-1,us-west-2,ca-central-1,us-west-1,us-east-2,us-east-1,ap-southeast-2,af-south-1,sa-east-1
+RW;Rwanda;af-south-1;af-south-1,me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-southeast-1,sa-east-1,ap-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+SA;Saudi Arabia;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,ap-southeast-1,ap-east-1,af-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,sa-east-1,us-west-2,ap-southeast-2,us-west-1
+SB;Solomon Islands;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-east-1,ap-northeast-2,ap-southeast-1,us-west-1,us-west-2,ap-south-1,me-south-1,us-east-2,us-east-1,eu-north-1,ca-central-1,af-south-1,eu-central-1,eu-west-2,eu-west-1,eu-south-1,eu-west-3,sa-east-1
+SC;Seychelles;ap-south-1;ap-south-1,me-south-1,af-south-1,ap-southeast-1,ap-east-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,ap-northeast-2,eu-west-1,ap-northeast-3,ap-northeast-1,ap-southeast-2,sa-east-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+SD;Sudan;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-west-3,ap-south-1,eu-west-2,eu-north-1,eu-west-1,af-south-1,ap-southeast-1,ap-east-1,sa-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,us-west-2,us-west-1,ap-southeast-2
+SE;Sweden;eu-north-1;eu-north-1,eu-central-1,eu-west-2,eu-west-3,eu-west-1,eu-south-1,me-south-1,ca-central-1,ap-south-1,us-east-1,us-east-2,ap-northeast-2,us-west-2,ap-northeast-3,ap-northeast-1,ap-east-1,us-west-1,ap-southeast-1,af-south-1,sa-east-1,ap-southeast-2
+SG;Singapore;ap-southeast-1;ap-southeast-1,ap-east-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2,me-south-1,eu-north-1,af-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+SH;Saint Helena;af-south-1;af-south-1,sa-east-1,eu-south-1,eu-west-3,eu-central-1,eu-west-2,me-south-1,eu-west-1,eu-north-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,us-west-1,us-west-2,ap-east-1,ap-southeast-2,ap-northeast-2,ap-northeast-3,ap-northeast-1
+SI;Slovenia;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,af-south-1,ap-east-1,us-west-2,ap-northeast-3,ap-northeast-1,us-west-1,ap-southeast-1,sa-east-1,ap-southeast-2
+SJ;Svalbard and Jan Mayen;eu-north-1;eu-north-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1,ca-central-1,us-east-2,me-south-1,us-west-2,us-east-1,ap-northeast-2,ap-northeast-1,ap-northeast-3,us-west-1,ap-south-1,ap-east-1,ap-southeast-1,sa-east-1,af-south-1,ap-southeast-2
+SK;Slovakia;eu-central-1;eu-central-1,eu-south-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,ap-east-1,ap-northeast-3,us-west-2,ap-northeast-1,af-south-1,ap-southeast-1,us-west-1,sa-east-1,ap-southeast-2
+SL;Sierra Leone;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-central-1,eu-west-1,sa-east-1,af-south-1,eu-north-1,me-south-1,ca-central-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+SM;San Marino;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,af-south-1,ap-northeast-2,us-west-2,ap-east-1,ap-northeast-3,sa-east-1,ap-northeast-1,us-west-1,ap-southeast-1,ap-southeast-2
+SN;Senegal;eu-south-1;eu-south-1,eu-west-3,eu-west-2,eu-west-1,eu-central-1,sa-east-1,eu-north-1,af-south-1,ca-central-1,me-south-1,us-east-1,us-east-2,ap-south-1,us-west-2,us-west-1,ap-southeast-1,ap-northeast-2,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+SO;Somalia;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,af-south-1,eu-north-1,eu-west-3,ap-southeast-1,eu-west-2,eu-west-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-2,us-east-1,us-east-2,us-west-2,us-west-1
+SR;Suriname;sa-east-1;sa-east-1,us-east-1,us-east-2,ca-central-1,eu-west-1,eu-west-2,eu-west-3,us-west-1,eu-south-1,eu-central-1,us-west-2,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+SS;South Sudan;me-south-1;me-south-1,eu-south-1,af-south-1,eu-central-1,eu-west-3,ap-south-1,eu-west-2,eu-north-1,eu-west-1,sa-east-1,ap-southeast-1,ap-east-1,ca-central-1,ap-northeast-2,us-east-1,us-east-2,ap-northeast-3,ap-northeast-1,us-west-2,ap-southeast-2,us-west-1
+ST;Sao Tome and Principe;af-south-1;af-south-1,eu-south-1,eu-west-3,me-south-1,eu-central-1,eu-west-2,eu-west-1,sa-east-1,eu-north-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,ap-east-1,ap-northeast-2,us-west-2,us-west-1,ap-northeast-3,ap-northeast-1,ap-southeast-2
+SV;El Salvador;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-southeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-1
+SX;Sint Maarten;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,eu-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-east-1,ap-southeast-2,ap-southeast-1
+SY;Syrian Arab Republic;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,ap-south-1,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-1,af-south-1,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+SZ;Swaziland;ap-southeast-1;af-south-1,me-south-1,ap-south-1,sa-east-1,eu-south-1,ap-southeast-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-east-1,ap-southeast-2,ap-northeast-2,ap-northeast-3,ca-central-1,ap-northeast-1,us-east-1,us-east-2,us-west-2,us-west-1
+TC;Turks and Caicos Islands;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,sa-east-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+TD;Chad;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,af-south-1,ap-south-1,sa-east-1,ca-central-1,ap-southeast-1,us-east-1,ap-east-1,us-east-2,ap-northeast-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1,ap-southeast-2
+TF;French Southern Territories;af-south-1;af-south-1,ap-southeast-1,ap-south-1,ap-southeast-2,me-south-1,ap-east-1,sa-east-1,ap-northeast-2,ap-northeast-3,eu-south-1,ap-northeast-1,eu-central-1,eu-west-3,eu-north-1,eu-west-2,eu-west-1,ca-central-1,us-east-1,us-east-2,us-west-1,us-west-2
+TG;Togo;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,af-south-1,eu-west-1,me-south-1,eu-north-1,sa-east-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-southeast-1,us-west-2,ap-east-1,us-west-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-2
+TH;Thailand;ap-southeast-1;ap-southeast-1,ap-east-1,ap-south-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+TJ;Tajikistan;ap-south-1;ap-south-1,me-south-1,eu-north-1,ap-east-1,ap-northeast-2,eu-central-1,eu-south-1,ap-southeast-1,eu-west-3,eu-west-2,ap-northeast-3,ap-northeast-1,eu-west-1,af-south-1,ca-central-1,us-west-2,us-east-2,us-east-1,us-west-1,ap-southeast-2,sa-east-1
+TK;Tokelau;ap-southeast-2;ap-southeast-2,ap-northeast-1,us-west-1,ap-northeast-3,us-west-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,ap-south-1,sa-east-1,eu-north-1,eu-west-1,af-south-1,me-south-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+TL;Timor-Leste;ap-southeast-1;None
+TM;Turkmenistan;me-south-1;me-south-1,ap-south-1,eu-north-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-1,ap-northeast-3,ap-northeast-1,af-south-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,ap-southeast-2,sa-east-1
+TN;Tunisia;eu-south-1;eu-south-1,eu-west-3,eu-central-1,eu-west-2,eu-west-1,eu-north-1,me-south-1,ap-south-1,ca-central-1,us-east-1,af-south-1,us-east-2,sa-east-1,ap-northeast-2,us-west-2,ap-east-1,ap-southeast-1,ap-northeast-3,us-west-1,ap-northeast-1,ap-southeast-2
+TO;Tonga;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,us-west-1,ap-northeast-2,us-west-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,sa-east-1,ap-south-1,af-south-1,me-south-1,eu-north-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+TR;Turkey;me-south-1;me-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,eu-west-1,ap-south-1,ap-east-1,ap-northeast-2,ap-southeast-1,ca-central-1,af-south-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+TT;Trinidad and Tobago;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,eu-west-2,us-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+TV;Tuvalu;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,us-west-1,ap-southeast-1,us-west-2,us-east-2,us-east-1,ap-south-1,ca-central-1,sa-east-1,eu-north-1,me-south-1,af-south-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+TW;Taiwan;ap-east-1;ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ap-southeast-1,ap-south-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,us-west-2,eu-west-2,eu-west-3,eu-west-1,us-west-1,ca-central-1,us-east-2,af-south-1,us-east-1,sa-east-1
+TZ;Tanzania, United Republic of;af-south-1;af-south-1,me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,ap-southeast-1,eu-west-1,sa-east-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,ap-southeast-2,us-east-1,us-east-2,us-west-2,us-west-1
+UA;Ukraine;eu-north-1;eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,me-south-1,ap-south-1,ap-northeast-2,ca-central-1,ap-east-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,ap-southeast-1,us-west-2,af-south-1,us-west-1,sa-east-1,ap-southeast-2
+UG;Uganda;me-south-1;me-south-1,af-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,ap-southeast-1,sa-east-1,ap-east-1,ap-northeast-2,ca-central-1,ap-northeast-3,ap-northeast-1,us-east-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+UM;United States Minor Outlying Islands;ap-northeast-1;ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-2,us-west-2,ap-southeast-1,us-west-1,ap-south-1,us-east-2,ca-central-1,us-east-1,eu-north-1,me-south-1,eu-west-1,eu-central-1,eu-west-2,eu-west-3,eu-south-1,af-south-1,sa-east-1
+US;United States;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-2,af-south-1,ap-southeast-1
+UY;Uruguay;sa-east-1;sa-east-1,af-south-1,us-east-1,us-east-2,ca-central-1,us-west-1,eu-west-1,eu-west-3,eu-west-2,eu-south-1,us-west-2,eu-central-1,ap-southeast-2,eu-north-1,me-south-1,ap-south-1,ap-southeast-1,ap-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2
+UZ;Uzbekistan;me-south-1;me-south-1,ap-south-1,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,ap-east-1,ap-northeast-2,eu-west-1,ap-southeast-1,ap-northeast-3,ap-northeast-1,ca-central-1,af-south-1,us-west-2,us-east-2,us-east-1,us-west-1,ap-southeast-2,sa-east-1
+VA;Holy See (Vatican City State);eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-west-1,eu-north-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,af-south-1,ap-northeast-2,ap-east-1,us-west-2,sa-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,us-west-1,ap-southeast-2
+VC;Saint Vincent and the Grenadines;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,eu-west-1,us-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-southeast-2,ap-east-1,ap-southeast-1
+VE;Venezuela;sa-east-1;us-east-1,us-east-2,sa-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-south-1,ap-northeast-3,ap-northeast-2,ap-southeast-2,ap-east-1,ap-southeast-1
+VG;Virgin Islands, British;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,eu-west-1,us-west-2,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+VI;Virgin Islands, U.S.;us-east-1;us-east-1,us-east-2,ca-central-1,sa-east-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-south-1,eu-north-1,af-south-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+VN;Vietnam;ap-east-1;ap-east-1,ap-southeast-1,ap-northeast-2,ap-south-1,ap-northeast-3,ap-northeast-1,me-south-1,ap-southeast-2,eu-north-1,eu-central-1,eu-south-1,eu-west-3,eu-west-2,eu-west-1,af-south-1,us-west-2,us-west-1,ca-central-1,us-east-2,us-east-1,sa-east-1
+VU;Vanuatu;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,ap-east-1,ap-southeast-1,ap-northeast-2,us-west-1,us-west-2,ap-south-1,us-east-2,us-east-1,me-south-1,af-south-1,ca-central-1,sa-east-1,eu-north-1,eu-central-1,eu-west-1,eu-west-2,eu-west-3,eu-south-1
+WF;Wallis and Futuna;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,us-west-1,ap-northeast-2,us-west-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,ap-south-1,sa-east-1,af-south-1,eu-north-1,me-south-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+WS;Samoa;ap-southeast-2;ap-southeast-2,ap-northeast-1,ap-northeast-3,us-west-1,us-west-2,ap-northeast-2,ap-east-1,ap-southeast-1,us-east-2,us-east-1,ca-central-1,sa-east-1,ap-south-1,af-south-1,eu-north-1,me-south-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1
+XK;Kosovo;eu-south-1;eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,eu-west-1,me-south-1,ap-south-1,ca-central-1,us-east-1,us-east-2,ap-northeast-2,af-south-1,ap-east-1,ap-northeast-3,ap-northeast-1,ap-southeast-1,us-west-2,sa-east-1,us-west-1,ap-southeast-2
+YE;Yemen;me-south-1;me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-north-1,eu-west-3,eu-west-2,af-south-1,ap-southeast-1,eu-west-1,ap-east-1,ap-northeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,sa-east-1,us-east-1,us-east-2,ap-southeast-2,us-west-2,us-west-1
+YT;Mayotte;af-south-1;af-south-1,me-south-1,ap-south-1,ap-southeast-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,eu-north-1,ap-east-1,eu-west-1,sa-east-1,ap-northeast-2,ap-southeast-2,ap-northeast-3,ap-northeast-1,ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1
+ZA;South Africa;ap-southeast-1;af-south-1,me-south-1,sa-east-1,ap-south-1,eu-south-1,eu-west-3,eu-central-1,ap-southeast-1,eu-west-2,eu-west-1,eu-north-1,ap-southeast-2,ap-east-1,ca-central-1,us-east-1,ap-northeast-2,us-east-2,ap-northeast-3,ap-northeast-1,us-west-2,us-west-1
+ZM;Zambia;eu-west-1;af-south-1,me-south-1,ap-south-1,eu-south-1,eu-central-1,eu-west-3,eu-west-2,sa-east-1,ap-southeast-1,eu-north-1,eu-west-1,ap-east-1,ap-northeast-2,ap-southeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,us-west-2,us-west-1
+ZW;Zimbabwe;eu-west-1;af-south-1,me-south-1,ap-south-1,eu-south-1,sa-east-1,eu-central-1,eu-west-3,ap-southeast-1,eu-west-2,eu-north-1,eu-west-1,ap-east-1,ap-southeast-2,ap-northeast-2,ca-central-1,ap-northeast-3,us-east-1,ap-northeast-1,us-east-2,us-west-2,us-west-1

--- a/output/map.html
+++ b/output/map.html
@@ -1104,17 +1104,17 @@ ProcessCable("CBUS", "4.80000000000e+002", "http://www.cwbda.com/", "", "1.60000
 
     
     var M1 = new google.maps.Marker({
-      position: new google.maps.LatLng(45.43, 9.29),
+      position: new google.maps.LatLng(38.13, -78.45),
       map: map,
-      title:"Milan (eu-south-1)"
+      title:"Virginia (us-east-1)"
     });
     M1.setMap(map);
 
 
     var M2 = new google.maps.Marker({
-      position: new google.maps.LatLng(19.08, 72.88),
+      position: new google.maps.LatLng(39.96, -83.0),
       map: map,
-      title:"Mumbai (ap-south-1)"
+      title:"Ohio (us-east-2)"
     });
     M2.setMap(map);
 
@@ -1128,73 +1128,73 @@ ProcessCable("CBUS", "4.80000000000e+002", "http://www.cwbda.com/", "", "1.60000
 
 
     var M4 = new google.maps.Marker({
-      position: new google.maps.LatLng(34.69, 135.49),
+      position: new google.maps.LatLng(45.43, 9.29),
       map: map,
-      title:"Osaka (ap-northeast-3)"
+      title:"Milan (eu-south-1)"
     });
     M4.setMap(map);
 
 
     var M5 = new google.maps.Marker({
-      position: new google.maps.LatLng(38.13, -78.45),
+      position: new google.maps.LatLng(37.35, -121.96),
       map: map,
-      title:"Virginia (us-east-1)"
+      title:"California (us-west-1)"
     });
     M5.setMap(map);
 
 
     var M6 = new google.maps.Marker({
-      position: new google.maps.LatLng(39.96, -83.0),
+      position: new google.maps.LatLng(46.15, -123.88),
       map: map,
-      title:"Ohio (us-east-2)"
+      title:"Oregon (us-west-2)"
     });
     M6.setMap(map);
 
 
     var M7 = new google.maps.Marker({
-      position: new google.maps.LatLng(35.41, 139.42),
+      position: new google.maps.LatLng(53.0, -8.0),
       map: map,
-      title:"Tokyo (ap-northeast-1)"
+      title:"Ireland (eu-west-1)"
     });
     M7.setMap(map);
 
 
     var M8 = new google.maps.Marker({
-      position: new google.maps.LatLng(-23.34, -46.38),
+      position: new google.maps.LatLng(51.0, -0.1),
       map: map,
-      title:"Sao Paulo (sa-east-1)"
+      title:"London (eu-west-2)"
     });
     M8.setMap(map);
 
 
     var M9 = new google.maps.Marker({
-      position: new google.maps.LatLng(37.56, 126.98),
+      position: new google.maps.LatLng(48.86, 2.35),
       map: map,
-      title:"Seoul (ap-northeast-2)"
+      title:"Paris (eu-west-3)"
     });
     M9.setMap(map);
 
 
     var M10 = new google.maps.Marker({
-      position: new google.maps.LatLng(-33.93, 18.42),
+      position: new google.maps.LatLng(50.0, 8.0),
       map: map,
-      title:"South Africa (af-south)"
+      title:"Frankfurt (eu-central-1)"
     });
     M10.setMap(map);
 
 
     var M11 = new google.maps.Marker({
-      position: new google.maps.LatLng(1.37, 103.8),
+      position: new google.maps.LatLng(-23.34, -46.38),
       map: map,
-      title:"Singapore (ap-southeast-1)"
+      title:"Sao Paulo (sa-east-1)"
     });
     M11.setMap(map);
 
 
     var M12 = new google.maps.Marker({
-      position: new google.maps.LatLng(45.5, -73.6),
+      position: new google.maps.LatLng(1.37, 103.8),
       map: map,
-      title:"Canada Central (ca-central-1)"
+      title:"Singapore (ap-southeast-1)"
     });
     M12.setMap(map);
 
@@ -1208,1015 +1208,1015 @@ ProcessCable("CBUS", "4.80000000000e+002", "http://www.cwbda.com/", "", "1.60000
 
 
     var M14 = new google.maps.Marker({
-      position: new google.maps.LatLng(46.15, -123.88),
+      position: new google.maps.LatLng(35.41, 139.42),
       map: map,
-      title:"Oregon (us-west-2)"
+      title:"Tokyo (ap-northeast-1)"
     });
     M14.setMap(map);
 
 
     var M15 = new google.maps.Marker({
-      position: new google.maps.LatLng(22.27, 114.16),
+      position: new google.maps.LatLng(37.56, 126.98),
       map: map,
-      title:"Hong Kong (ap-east-1)"
+      title:"Seoul (ap-northeast-2)"
     });
     M15.setMap(map);
 
 
     var M16 = new google.maps.Marker({
-      position: new google.maps.LatLng(26.1, 50.46),
+      position: new google.maps.LatLng(34.69, 135.49),
       map: map,
-      title:"Bahrain (me-south-1)"
+      title:"Osaka (ap-northeast-3)"
     });
     M16.setMap(map);
 
 
     var M17 = new google.maps.Marker({
-      position: new google.maps.LatLng(37.35, -121.96),
+      position: new google.maps.LatLng(19.08, 72.88),
       map: map,
-      title:"California (us-west-1)"
+      title:"Mumbai (ap-south-1)"
     });
     M17.setMap(map);
 
 
     var M18 = new google.maps.Marker({
-      position: new google.maps.LatLng(50.0, 8.0),
+      position: new google.maps.LatLng(45.5, -73.6),
       map: map,
-      title:"Frankfurt (eu-central-1)"
+      title:"Canada Central (ca-central-1)"
     });
     M18.setMap(map);
 
 
     var M19 = new google.maps.Marker({
-      position: new google.maps.LatLng(53.0, -8.0),
+      position: new google.maps.LatLng(22.27, 114.16),
       map: map,
-      title:"Ireland (eu-west-1)"
+      title:"Hong Kong (ap-east-1)"
     });
     M19.setMap(map);
 
 
     var M20 = new google.maps.Marker({
-      position: new google.maps.LatLng(51.0, -0.1),
+      position: new google.maps.LatLng(26.1, 50.46),
       map: map,
-      title:"London (eu-west-2)"
+      title:"Bahrain (me-south-1)"
     });
     M20.setMap(map);
 
 
     var M21 = new google.maps.Marker({
-      position: new google.maps.LatLng(48.86, 2.35),
+      position: new google.maps.LatLng(-33.93, 18.42),
       map: map,
-      title:"Paris (eu-west-3)"
+      title:"South Africa (af-south-1)"
     });
     M21.setMap(map);
 
     
-    var L1 = [ new google.maps.LatLng(-2.0, 30.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L1 = [ new google.maps.LatLng(42.5, 1.5), new google.maps.LatLng(45.43, 9.29)];
     var P1 = new google.maps.Polyline({ path: L1, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P1.setMap(map);
 
 
-    var L2 = [ new google.maps.LatLng(4.5, 114.67), new google.maps.LatLng(1.37, 103.8)];
+    var L2 = [ new google.maps.LatLng(24.0, 54.0), new google.maps.LatLng(26.1, 50.46)];
     var P2 = new google.maps.Polyline({ path: L2, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P2.setMap(map);
 
 
-    var L3 = [ new google.maps.LatLng(18.5, -64.5), new google.maps.LatLng(38.13, -78.45)];
+    var L3 = [ new google.maps.LatLng(33.0, 65.0), new google.maps.LatLng(26.1, 50.46)];
     var P3 = new google.maps.Polyline({ path: L3, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P3.setMap(map);
 
 
-    var L4 = [ new google.maps.LatLng(40.0, 45.0), new google.maps.LatLng(26.1, 50.46)];
+    var L4 = [ new google.maps.LatLng(17.05, -61.8), new google.maps.LatLng(38.13, -78.45)];
     var P4 = new google.maps.Polyline({ path: L4, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P4.setMap(map);
 
 
-    var L5 = [ new google.maps.LatLng(0.0, 25.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L5 = [ new google.maps.LatLng(18.25, -63.17), new google.maps.LatLng(38.13, -78.45)];
     var P5 = new google.maps.Polyline({ path: L5, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P5.setMap(map);
 
 
-    var L6 = [ new google.maps.LatLng(39.45, -74.57), new google.maps.LatLng(38.13, -78.45)];
+    var L6 = [ new google.maps.LatLng(41.0, 20.0), new google.maps.LatLng(45.43, 9.29)];
     var P6 = new google.maps.Polyline({ path: L6, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P6.setMap(map);
 
 
-    var L7 = [ new google.maps.LatLng(38.0, -97.0), new google.maps.LatLng(39.96, -83.0)];
+    var L7 = [ new google.maps.LatLng(40.0, 45.0), new google.maps.LatLng(26.1, 50.46)];
     var P7 = new google.maps.Polyline({ path: L7, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P7.setMap(map);
 
 
-    var L8 = [ new google.maps.LatLng(39.38, -86.5), new google.maps.LatLng(39.96, -83.0)];
+    var L8 = [ new google.maps.LatLng(12.25, -68.75), new google.maps.LatLng(38.13, -78.45)];
     var P8 = new google.maps.Polyline({ path: L8, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P8.setMap(map);
 
 
-    var L9 = [ new google.maps.LatLng(7.5, 134.5), new google.maps.LatLng(22.27, 114.16)];
+    var L9 = [ new google.maps.LatLng(-12.5, 18.5), new google.maps.LatLng(53.0, -8.0)];
     var P9 = new google.maps.Polyline({ path: L9, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P9.setMap(map);
 
 
-    var L10 = [ new google.maps.LatLng(52.5, 5.75), new google.maps.LatLng(53.0, -8.0)];
+    var L10 = [ new google.maps.LatLng(35.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
     var P10 = new google.maps.Polyline({ path: L10, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P10.setMap(map);
 
 
-    var L11 = [ new google.maps.LatLng(41.0, 64.0), new google.maps.LatLng(26.1, 50.46)];
+    var L11 = [ new google.maps.LatLng(-34.0, -64.0), new google.maps.LatLng(-23.34, -46.38)];
     var P11 = new google.maps.Polyline({ path: L11, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P11.setMap(map);
 
 
-    var L12 = [ new google.maps.LatLng(21.5, -80.0), new google.maps.LatLng(38.13, -78.45)];
+    var L12 = [ new google.maps.LatLng(-14.33, -170.0), new google.maps.LatLng(-33.86, 151.2)];
     var P12 = new google.maps.Polyline({ path: L12, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P12.setMap(map);
 
 
-    var L13 = [ new google.maps.LatLng(32.0, 35.25), new google.maps.LatLng(26.1, 50.46)];
+    var L13 = [ new google.maps.LatLng(47.33, 13.33), new google.maps.LatLng(45.43, 9.29)];
     var P13 = new google.maps.Polyline({ path: L13, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P13.setMap(map);
 
 
-    var L14 = [ new google.maps.LatLng(18.25, -66.5), new google.maps.LatLng(38.13, -78.45)];
+    var L14 = [ new google.maps.LatLng(-27.0, 133.0), new google.maps.LatLng(-33.86, 151.2)];
     var P14 = new google.maps.Polyline({ path: L14, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P14.setMap(map);
 
 
-    var L15 = [ new google.maps.LatLng(-18.0, 175.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L15 = [ new google.maps.LatLng(12.5, -69.97), new google.maps.LatLng(38.13, -78.45)];
     var P15 = new google.maps.Polyline({ path: L15, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P15.setMap(map);
 
 
-    var L16 = [ new google.maps.LatLng(8.0, -2.0), new google.maps.LatLng(45.43, 9.29)];
+    var L16 = [ new google.maps.LatLng(40.5, 47.5), new google.maps.LatLng(26.1, 50.46)];
     var P16 = new google.maps.Polyline({ path: L16, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P16.setMap(map);
 
 
-    var L17 = [ new google.maps.LatLng(29.73, -85.03), new google.maps.LatLng(38.13, -78.45)];
+    var L17 = [ new google.maps.LatLng(44.0, 18.0), new google.maps.LatLng(45.43, 9.29)];
     var P17 = new google.maps.Polyline({ path: L17, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P17.setMap(map);
 
 
-    var L18 = [ new google.maps.LatLng(8.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
+    var L18 = [ new google.maps.LatLng(13.17, -59.53), new google.maps.LatLng(38.13, -78.45)];
     var P18 = new google.maps.Polyline({ path: L18, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P18.setMap(map);
 
 
-    var L19 = [ new google.maps.LatLng(31.38, -92.3), new google.maps.LatLng(39.96, -83.0)];
+    var L19 = [ new google.maps.LatLng(24.0, 90.0), new google.maps.LatLng(19.08, 72.88)];
     var P19 = new google.maps.Polyline({ path: L19, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P19.setMap(map);
 
 
-    var L20 = [ new google.maps.LatLng(-21.5, 165.5), new google.maps.LatLng(-33.86, 151.2)];
+    var L20 = [ new google.maps.LatLng(50.83, 4.0), new google.maps.LatLng(48.86, 2.35)];
     var P20 = new google.maps.Polyline({ path: L20, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P20.setMap(map);
 
 
-    var L21 = [ new google.maps.LatLng(35.0, 33.0), new google.maps.LatLng(26.1, 50.46)];
+    var L21 = [ new google.maps.LatLng(13.0, -2.0), new google.maps.LatLng(45.43, 9.29)];
     var P21 = new google.maps.Polyline({ path: L21, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P21.setMap(map);
 
 
-    var L22 = [ new google.maps.LatLng(-6.0, 147.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L22 = [ new google.maps.LatLng(43.0, 25.0), new google.maps.LatLng(45.43, 9.29)];
     var P22 = new google.maps.Polyline({ path: L22, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P22.setMap(map);
 
 
-    var L23 = [ new google.maps.LatLng(-16.0, 167.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L23 = [ new google.maps.LatLng(26.0, 50.55), new google.maps.LatLng(26.1, 50.46)];
     var P23 = new google.maps.Polyline({ path: L23, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P23.setMap(map);
 
 
-    var L24 = [ new google.maps.LatLng(20.0, -12.0), new google.maps.LatLng(45.43, 9.29)];
+    var L24 = [ new google.maps.LatLng(-3.5, 30.0), new google.maps.LatLng(-33.93, 18.42)];
     var P24 = new google.maps.Polyline({ path: L24, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P24.setMap(map);
 
 
-    var L25 = [ new google.maps.LatLng(-12.17, 44.25), new google.maps.LatLng(-33.93, 18.42)];
+    var L25 = [ new google.maps.LatLng(9.5, 2.25), new google.maps.LatLng(45.43, 9.29)];
     var P25 = new google.maps.Polyline({ path: L25, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P25.setMap(map);
 
 
-    var L26 = [ new google.maps.LatLng(47.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
+    var L26 = [ new google.maps.LatLng(17.92, -62.94), new google.maps.LatLng(38.13, -78.45)];
     var P26 = new google.maps.Polyline({ path: L26, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P26.setMap(map);
 
 
-    var L27 = [ new google.maps.LatLng(31.0, 36.0), new google.maps.LatLng(26.1, 50.46)];
+    var L27 = [ new google.maps.LatLng(14.81, -67.97), new google.maps.LatLng(38.13, -78.45)];
     var P27 = new google.maps.Polyline({ path: L27, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P27.setMap(map);
 
 
-    var L28 = [ new google.maps.LatLng(37.67, -95.48), new google.maps.LatLng(39.96, -83.0)];
+    var L28 = [ new google.maps.LatLng(32.33, -64.75), new google.maps.LatLng(38.13, -78.45)];
     var P28 = new google.maps.Polyline({ path: L28, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P28.setMap(map);
 
 
-    var L29 = [ new google.maps.LatLng(-22.0, 17.0), new google.maps.LatLng(53.0, -8.0)];
+    var L29 = [ new google.maps.LatLng(4.5, 114.67), new google.maps.LatLng(1.37, 103.8)];
     var P29 = new google.maps.Polyline({ path: L29, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P29.setMap(map);
 
 
-    var L30 = [ new google.maps.LatLng(22.0, 98.0), new google.maps.LatLng(22.27, 114.16)];
+    var L30 = [ new google.maps.LatLng(-17.0, -65.0), new google.maps.LatLng(-23.34, -46.38)];
     var P30 = new google.maps.Polyline({ path: L30, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P30.setMap(map);
 
 
-    var L31 = [ new google.maps.LatLng(35.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
+    var L31 = [ new google.maps.LatLng(-10.0, -55.0), new google.maps.LatLng(-23.34, -46.38)];
     var P31 = new google.maps.Polyline({ path: L31, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P31.setMap(map);
 
 
-    var L32 = [ new google.maps.LatLng(24.5, -13.0), new google.maps.LatLng(48.86, 2.35)];
+    var L32 = [ new google.maps.LatLng(24.25, -76.0), new google.maps.LatLng(38.13, -78.45)];
     var P32 = new google.maps.Polyline({ path: L32, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P32.setMap(map);
 
 
-    var L33 = [ new google.maps.LatLng(-54.5, -37.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L33 = [ new google.maps.LatLng(27.5, 90.5), new google.maps.LatLng(19.08, 72.88)];
     var P33 = new google.maps.Polyline({ path: L33, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P33.setMap(map);
 
 
-    var L34 = [ new google.maps.LatLng(34.5, -82.72), new google.maps.LatLng(38.13, -78.45)];
+    var L34 = [ new google.maps.LatLng(-54.43, 3.4), new google.maps.LatLng(-33.93, 18.42)];
     var P34 = new google.maps.Polyline({ path: L34, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P34.setMap(map);
 
 
-    var L35 = [ new google.maps.LatLng(-15.0, 30.0), new google.maps.LatLng(53.0, -8.0)];
+    var L35 = [ new google.maps.LatLng(-22.0, 24.0), new google.maps.LatLng(53.0, -8.0)];
     var P35 = new google.maps.Polyline({ path: L35, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P35.setMap(map);
 
 
-    var L36 = [ new google.maps.LatLng(35.97, -89.95), new google.maps.LatLng(39.96, -83.0)];
+    var L36 = [ new google.maps.LatLng(53.0, 28.0), new google.maps.LatLng(59.25, 17.81)];
     var P36 = new google.maps.Polyline({ path: L36, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P36.setMap(map);
 
 
-    var L37 = [ new google.maps.LatLng(13.0, 122.0), new google.maps.LatLng(22.27, 114.16)];
+    var L37 = [ new google.maps.LatLng(17.25, -88.75), new google.maps.LatLng(38.13, -78.45)];
     var P37 = new google.maps.Polyline({ path: L37, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P37.setMap(map);
 
 
-    var L38 = [ new google.maps.LatLng(-12.83, 45.17), new google.maps.LatLng(-33.93, 18.42)];
+    var L38 = [ new google.maps.LatLng(59.0, -105.0), new google.maps.LatLng(46.15, -123.88)];
     var P38 = new google.maps.Polyline({ path: L38, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P38.setMap(map);
 
 
-    var L39 = [ new google.maps.LatLng(-18.25, 35.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L39 = [ new google.maps.LatLng(-12.5, 96.83), new google.maps.LatLng(1.37, 103.8)];
     var P39 = new google.maps.Polyline({ path: L39, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P39.setMap(map);
 
 
-    var L40 = [ new google.maps.LatLng(44.47, -73.15), new google.maps.LatLng(45.5, -73.6)];
+    var L40 = [ new google.maps.LatLng(0.0, 25.0), new google.maps.LatLng(-33.93, 18.42)];
     var P40 = new google.maps.Polyline({ path: L40, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P40.setMap(map);
 
 
-    var L41 = [ new google.maps.LatLng(28.0, 84.0), new google.maps.LatLng(19.08, 72.88)];
+    var L41 = [ new google.maps.LatLng(7.0, 21.0), new google.maps.LatLng(26.1, 50.46)];
     var P41 = new google.maps.Polyline({ path: L41, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P41.setMap(map);
 
 
-    var L42 = [ new google.maps.LatLng(28.0, 3.0), new google.maps.LatLng(45.43, 9.29)];
+    var L42 = [ new google.maps.LatLng(-1.0, 15.0), new google.maps.LatLng(-33.93, 18.42)];
     var P42 = new google.maps.Polyline({ path: L42, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P42.setMap(map);
 
 
-    var L43 = [ new google.maps.LatLng(-53.1, 72.52), new google.maps.LatLng(-33.93, 18.42)];
+    var L43 = [ new google.maps.LatLng(47.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
     var P43 = new google.maps.Polyline({ path: L43, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P43.setMap(map);
 
 
-    var L44 = [ new google.maps.LatLng(9.5, 2.25), new google.maps.LatLng(45.43, 9.29)];
+    var L44 = [ new google.maps.LatLng(8.0, -5.0), new google.maps.LatLng(45.43, 9.29)];
     var P44 = new google.maps.Polyline({ path: L44, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P44.setMap(map);
 
 
-    var L45 = [ new google.maps.LatLng(22.25, 114.17), new google.maps.LatLng(22.27, 114.16)];
+    var L45 = [ new google.maps.LatLng(-21.23, -159.77), new google.maps.LatLng(-33.86, 151.2)];
     var P45 = new google.maps.Polyline({ path: L45, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P45.setMap(map);
 
 
-    var L46 = [ new google.maps.LatLng(51.88, -176.65), new google.maps.LatLng(46.15, -123.88)];
+    var L46 = [ new google.maps.LatLng(-30.0, -71.0), new google.maps.LatLng(-23.34, -46.38)];
     var P46 = new google.maps.Polyline({ path: L46, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P46.setMap(map);
 
 
-    var L47 = [ new google.maps.LatLng(65.0, -18.0), new google.maps.LatLng(53.0, -8.0)];
+    var L47 = [ new google.maps.LatLng(6.0, 12.0), new google.maps.LatLng(45.43, 9.29)];
     var P47 = new google.maps.Polyline({ path: L47, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P47.setMap(map);
 
 
-    var L48 = [ new google.maps.LatLng(7.0, 81.0), new google.maps.LatLng(19.08, 72.88)];
+    var L48 = [ new google.maps.LatLng(35.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
     var P48 = new google.maps.Polyline({ path: L48, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P48.setMap(map);
 
 
-    var L49 = [ new google.maps.LatLng(31.53, -84.18), new google.maps.LatLng(38.13, -78.45)];
+    var L49 = [ new google.maps.LatLng(4.0, -72.0), new google.maps.LatLng(-23.34, -46.38)];
     var P49 = new google.maps.Polyline({ path: L49, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P49.setMap(map);
 
 
-    var L50 = [ new google.maps.LatLng(34.67, -99.27), new google.maps.LatLng(39.96, -83.0)];
+    var L50 = [ new google.maps.LatLng(10.0, -84.0), new google.maps.LatLng(38.13, -78.45)];
     var P50 = new google.maps.Polyline({ path: L50, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P50.setMap(map);
 
 
-    var L51 = [ new google.maps.LatLng(32.0, -5.0), new google.maps.LatLng(45.43, 9.29)];
+    var L51 = [ new google.maps.LatLng(21.5, -80.0), new google.maps.LatLng(38.13, -78.45)];
     var P51 = new google.maps.Polyline({ path: L51, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P51.setMap(map);
 
 
-    var L52 = [ new google.maps.LatLng(18.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
+    var L52 = [ new google.maps.LatLng(16.0, -24.0), new google.maps.LatLng(53.0, -8.0)];
     var P52 = new google.maps.Polyline({ path: L52, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P52.setMap(map);
 
 
-    var L53 = [ new google.maps.LatLng(17.25, -88.75), new google.maps.LatLng(38.13, -78.45)];
+    var L53 = [ new google.maps.LatLng(12.21, -69.21), new google.maps.LatLng(38.13, -78.45)];
     var P53 = new google.maps.Polyline({ path: L53, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P53.setMap(map);
 
 
-    var L54 = [ new google.maps.LatLng(-26.5, 31.5), new google.maps.LatLng(1.37, 103.8)];
+    var L54 = [ new google.maps.LatLng(-10.5, 105.67), new google.maps.LatLng(1.37, 103.8)];
     var P54 = new google.maps.Polyline({ path: L54, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P54.setMap(map);
 
 
-    var L55 = [ new google.maps.LatLng(49.75, 6.17), new google.maps.LatLng(50.0, 8.0)];
+    var L55 = [ new google.maps.LatLng(35.0, 33.0), new google.maps.LatLng(26.1, 50.46)];
     var P55 = new google.maps.Polyline({ path: L55, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P55.setMap(map);
 
 
-    var L56 = [ new google.maps.LatLng(-19.03, -169.87), new google.maps.LatLng(-33.86, 151.2)];
+    var L56 = [ new google.maps.LatLng(49.75, 15.5), new google.maps.LatLng(50.0, 8.0)];
     var P56 = new google.maps.Polyline({ path: L56, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P56.setMap(map);
 
 
-    var L57 = [ new google.maps.LatLng(12.21, -69.21), new google.maps.LatLng(38.13, -78.45)];
+    var L57 = [ new google.maps.LatLng(51.0, 9.0), new google.maps.LatLng(50.0, 8.0)];
     var P57 = new google.maps.Polyline({ path: L57, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P57.setMap(map);
 
 
-    var L58 = [ new google.maps.LatLng(62.0, -7.0), new google.maps.LatLng(53.0, -8.0)];
+    var L58 = [ new google.maps.LatLng(11.5, 43.0), new google.maps.LatLng(26.1, 50.46)];
     var P58 = new google.maps.Polyline({ path: L58, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P58.setMap(map);
 
 
-    var L59 = [ new google.maps.LatLng(15.0, 100.0), new google.maps.LatLng(1.37, 103.8)];
+    var L59 = [ new google.maps.LatLng(56.0, 10.0), new google.maps.LatLng(59.25, 17.81)];
     var P59 = new google.maps.Polyline({ path: L59, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P59.setMap(map);
 
 
-    var L60 = [ new google.maps.LatLng(-54.43, 3.4), new google.maps.LatLng(-33.93, 18.42)];
+    var L60 = [ new google.maps.LatLng(15.42, -61.33), new google.maps.LatLng(38.13, -78.45)];
     var P60 = new google.maps.Polyline({ path: L60, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P60.setMap(map);
 
 
-    var L61 = [ new google.maps.LatLng(43.68, -93.37), new google.maps.LatLng(39.96, -83.0)];
+    var L61 = [ new google.maps.LatLng(19.0, -70.67), new google.maps.LatLng(38.13, -78.45)];
     var P61 = new google.maps.Polyline({ path: L61, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P61.setMap(map);
 
 
-    var L62 = [ new google.maps.LatLng(-10.0, -76.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L62 = [ new google.maps.LatLng(28.0, 3.0), new google.maps.LatLng(45.43, 9.29)];
     var P62 = new google.maps.Polyline({ path: L62, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P62.setMap(map);
 
 
-    var L63 = [ new google.maps.LatLng(-29.03, 167.95), new google.maps.LatLng(-33.86, 151.2)];
+    var L63 = [ new google.maps.LatLng(-2.0, -77.5), new google.maps.LatLng(-23.34, -46.38)];
     var P63 = new google.maps.Polyline({ path: L63, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P63.setMap(map);
 
 
-    var L64 = [ new google.maps.LatLng(-20.28, 57.55), new google.maps.LatLng(-33.93, 18.42)];
+    var L64 = [ new google.maps.LatLng(59.0, 26.0), new google.maps.LatLng(59.25, 17.81)];
     var P64 = new google.maps.Polyline({ path: L64, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P64.setMap(map);
 
 
-    var L65 = [ new google.maps.LatLng(1.42, 173.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L65 = [ new google.maps.LatLng(27.0, 30.0), new google.maps.LatLng(26.1, 50.46)];
     var P65 = new google.maps.Polyline({ path: L65, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P65.setMap(map);
 
 
-    var L66 = [ new google.maps.LatLng(7.0, 21.0), new google.maps.LatLng(26.1, 50.46)];
+    var L66 = [ new google.maps.LatLng(24.5, -13.0), new google.maps.LatLng(48.86, 2.35)];
     var P66 = new google.maps.Polyline({ path: L66, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P66.setMap(map);
 
 
-    var L67 = [ new google.maps.LatLng(10.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
+    var L67 = [ new google.maps.LatLng(15.0, 39.0), new google.maps.LatLng(26.1, 50.46)];
     var P67 = new google.maps.Polyline({ path: L67, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P67.setMap(map);
 
 
-    var L68 = [ new google.maps.LatLng(6.0, 12.0), new google.maps.LatLng(45.43, 9.29)];
+    var L68 = [ new google.maps.LatLng(40.0, -4.0), new google.maps.LatLng(48.86, 2.35)];
     var P68 = new google.maps.Polyline({ path: L68, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P68.setMap(map);
 
 
-    var L69 = [ new google.maps.LatLng(-8.0, 178.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L69 = [ new google.maps.LatLng(8.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
     var P69 = new google.maps.Polyline({ path: L69, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P69.setMap(map);
 
 
-    var L70 = [ new google.maps.LatLng(39.83, -117.13), new google.maps.LatLng(37.35, -121.96)];
+    var L70 = [ new google.maps.LatLng(47.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
     var P70 = new google.maps.Polyline({ path: L70, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P70.setMap(map);
 
 
-    var L71 = [ new google.maps.LatLng(33.0, 65.0), new google.maps.LatLng(26.1, 50.46)];
+    var L71 = [ new google.maps.LatLng(64.0, 26.0), new google.maps.LatLng(59.25, 17.81)];
     var P71 = new google.maps.Polyline({ path: L71, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P71.setMap(map);
 
 
-    var L72 = [ new google.maps.LatLng(40.65, -75.43), new google.maps.LatLng(38.13, -78.45)];
+    var L72 = [ new google.maps.LatLng(-18.0, 175.0), new google.maps.LatLng(-33.86, 151.2)];
     var P72 = new google.maps.Polyline({ path: L72, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P72.setMap(map);
 
 
-    var L73 = [ new google.maps.LatLng(12.12, -61.67), new google.maps.LatLng(38.13, -78.45)];
+    var L73 = [ new google.maps.LatLng(-51.75, -59.0), new google.maps.LatLng(-23.34, -46.38)];
     var P73 = new google.maps.Polyline({ path: L73, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P73.setMap(map);
 
 
-    var L74 = [ new google.maps.LatLng(16.0, -24.0), new google.maps.LatLng(53.0, -8.0)];
+    var L74 = [ new google.maps.LatLng(6.92, 158.25), new google.maps.LatLng(35.41, 139.42)];
     var P74 = new google.maps.Polyline({ path: L74, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P74.setMap(map);
 
 
-    var L75 = [ new google.maps.LatLng(46.15, -123.88), new google.maps.LatLng(46.15, -123.88)];
+    var L75 = [ new google.maps.LatLng(62.0, -7.0), new google.maps.LatLng(53.0, -8.0)];
     var P75 = new google.maps.Polyline({ path: L75, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P75.setMap(map);
 
 
-    var L76 = [ new google.maps.LatLng(25.0, 17.0), new google.maps.LatLng(45.43, 9.29)];
+    var L76 = [ new google.maps.LatLng(46.0, 2.0), new google.maps.LatLng(48.86, 2.35)];
     var P76 = new google.maps.Polyline({ path: L76, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P76.setMap(map);
 
 
-    var L77 = [ new google.maps.LatLng(46.77, -100.75), new google.maps.LatLng(39.96, -83.0)];
+    var L77 = [ new google.maps.LatLng(-1.0, 11.75), new google.maps.LatLng(-33.93, 18.42)];
     var P77 = new google.maps.Polyline({ path: L77, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P77.setMap(map);
 
 
-    var L78 = [ new google.maps.LatLng(-2.0, -77.5), new google.maps.LatLng(-23.34, -46.38)];
+    var L78 = [ new google.maps.LatLng(54.0, -2.0), new google.maps.LatLng(51.0, -0.1)];
     var P78 = new google.maps.Polyline({ path: L78, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P78.setMap(map);
 
 
-    var L79 = [ new google.maps.LatLng(49.75, 15.5), new google.maps.LatLng(50.0, 8.0)];
+    var L79 = [ new google.maps.LatLng(12.12, -61.67), new google.maps.LatLng(38.13, -78.45)];
     var P79 = new google.maps.Polyline({ path: L79, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P79.setMap(map);
 
 
-    var L80 = [ new google.maps.LatLng(41.48, -120.53), new google.maps.LatLng(37.35, -121.96)];
+    var L80 = [ new google.maps.LatLng(42.0, 43.5), new google.maps.LatLng(26.1, 50.46)];
     var P80 = new google.maps.Polyline({ path: L80, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P80.setMap(map);
 
 
-    var L81 = [ new google.maps.LatLng(37.78, -81.12), new google.maps.LatLng(38.13, -78.45)];
+    var L81 = [ new google.maps.LatLng(4.0, -53.0), new google.maps.LatLng(-23.34, -46.38)];
     var P81 = new google.maps.Polyline({ path: L81, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P81.setMap(map);
 
 
-    var L82 = [ new google.maps.LatLng(12.25, -68.75), new google.maps.LatLng(38.13, -78.45)];
+    var L82 = [ new google.maps.LatLng(8.0, -2.0), new google.maps.LatLng(45.43, 9.29)];
     var P82 = new google.maps.Polyline({ path: L82, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P82.setMap(map);
 
 
-    var L83 = [ new google.maps.LatLng(43.73, 7.4), new google.maps.LatLng(45.43, 9.29)];
+    var L83 = [ new google.maps.LatLng(36.18, -5.37), new google.maps.LatLng(48.86, 2.35)];
     var P83 = new google.maps.Polyline({ path: L83, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P83.setMap(map);
 
 
-    var L84 = [ new google.maps.LatLng(59.0, 26.0), new google.maps.LatLng(59.25, 17.81)];
+    var L84 = [ new google.maps.LatLng(72.0, -40.0), new google.maps.LatLng(53.0, -8.0)];
     var P84 = new google.maps.Polyline({ path: L84, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P84.setMap(map);
 
 
-    var L85 = [ new google.maps.LatLng(8.0, -5.0), new google.maps.LatLng(45.43, 9.29)];
+    var L85 = [ new google.maps.LatLng(13.47, -16.57), new google.maps.LatLng(48.86, 2.35)];
     var P85 = new google.maps.Polyline({ path: L85, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P85.setMap(map);
 
 
-    var L86 = [ new google.maps.LatLng(33.83, 35.83), new google.maps.LatLng(26.1, 50.46)];
+    var L86 = [ new google.maps.LatLng(11.0, -10.0), new google.maps.LatLng(45.43, 9.29)];
     var P86 = new google.maps.Polyline({ path: L86, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P86.setMap(map);
 
 
-    var L87 = [ new google.maps.LatLng(13.0, -85.0), new google.maps.LatLng(38.13, -78.45)];
+    var L87 = [ new google.maps.LatLng(16.25, -61.58), new google.maps.LatLng(38.13, -78.45)];
     var P87 = new google.maps.Polyline({ path: L87, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P87.setMap(map);
 
 
-    var L88 = [ new google.maps.LatLng(23.0, -102.0), new google.maps.LatLng(37.35, -121.96)];
+    var L88 = [ new google.maps.LatLng(2.0, 10.0), new google.maps.LatLng(-33.93, 18.42)];
     var P88 = new google.maps.Polyline({ path: L88, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P88.setMap(map);
 
 
-    var L89 = [ new google.maps.LatLng(36.0, 138.0), new google.maps.LatLng(35.41, 139.42)];
+    var L89 = [ new google.maps.LatLng(39.0, 22.0), new google.maps.LatLng(45.43, 9.29)];
     var P89 = new google.maps.Polyline({ path: L89, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P89.setMap(map);
 
 
-    var L90 = [ new google.maps.LatLng(15.0, 39.0), new google.maps.LatLng(26.1, 50.46)];
+    var L90 = [ new google.maps.LatLng(-54.5, -37.0), new google.maps.LatLng(-23.34, -46.38)];
     var P90 = new google.maps.Polyline({ path: L90, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P90.setMap(map);
 
 
-    var L91 = [ new google.maps.LatLng(10.0, -84.0), new google.maps.LatLng(38.13, -78.45)];
+    var L91 = [ new google.maps.LatLng(15.5, -90.25), new google.maps.LatLng(38.13, -78.45)];
     var P91 = new google.maps.Polyline({ path: L91, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P91.setMap(map);
 
 
-    var L92 = [ new google.maps.LatLng(-14.33, -170.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L92 = [ new google.maps.LatLng(13.47, 144.78), new google.maps.LatLng(35.41, 139.42)];
     var P92 = new google.maps.Polyline({ path: L92, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P92.setMap(map);
 
 
-    var L93 = [ new google.maps.LatLng(14.67, -61.0), new google.maps.LatLng(38.13, -78.45)];
+    var L93 = [ new google.maps.LatLng(12.0, -15.0), new google.maps.LatLng(45.43, 9.29)];
     var P93 = new google.maps.Polyline({ path: L93, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P93.setMap(map);
 
 
-    var L94 = [ new google.maps.LatLng(8.5, -11.5), new google.maps.LatLng(45.43, 9.29)];
+    var L94 = [ new google.maps.LatLng(5.0, -59.0), new google.maps.LatLng(-23.34, -46.38)];
     var P94 = new google.maps.Polyline({ path: L94, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P94.setMap(map);
 
 
-    var L95 = [ new google.maps.LatLng(-9.0, -172.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L95 = [ new google.maps.LatLng(22.25, 114.17), new google.maps.LatLng(22.27, 114.16)];
     var P95 = new google.maps.Polyline({ path: L95, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P95.setMap(map);
 
 
-    var L96 = [ new google.maps.LatLng(21.53, -158.12), new google.maps.LatLng(37.35, -121.96)];
+    var L96 = [ new google.maps.LatLng(-53.1, 72.52), new google.maps.LatLng(-33.93, 18.42)];
     var P96 = new google.maps.Polyline({ path: L96, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P96.setMap(map);
 
 
-    var L97 = [ new google.maps.LatLng(57.0, 25.0), new google.maps.LatLng(59.25, 17.81)];
+    var L97 = [ new google.maps.LatLng(15.0, -86.5), new google.maps.LatLng(38.13, -78.45)];
     var P97 = new google.maps.Polyline({ path: L97, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P97.setMap(map);
 
 
-    var L98 = [ new google.maps.LatLng(13.25, -61.2), new google.maps.LatLng(38.13, -78.45)];
+    var L98 = [ new google.maps.LatLng(45.17, 15.5), new google.maps.LatLng(45.43, 9.29)];
     var P98 = new google.maps.Polyline({ path: L98, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P98.setMap(map);
 
 
-    var L99 = [ new google.maps.LatLng(36.97, -86.43), new google.maps.LatLng(39.96, -83.0)];
+    var L99 = [ new google.maps.LatLng(19.0, -72.42), new google.maps.LatLng(38.13, -78.45)];
     var P99 = new google.maps.Polyline({ path: L99, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P99.setMap(map);
 
 
-    var L100 = [ new google.maps.LatLng(-3.5, 30.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L100 = [ new google.maps.LatLng(47.0, 20.0), new google.maps.LatLng(45.43, 9.29)];
     var P100 = new google.maps.Polyline({ path: L100, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P100.setMap(map);
 
 
-    var L101 = [ new google.maps.LatLng(10.0, 49.0), new google.maps.LatLng(26.1, 50.46)];
+    var L101 = [ new google.maps.LatLng(-5.0, 120.0), new google.maps.LatLng(1.37, 103.8)];
     var P101 = new google.maps.Polyline({ path: L101, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P101.setMap(map);
 
 
-    var L102 = [ new google.maps.LatLng(78.0, 20.0), new google.maps.LatLng(59.25, 17.81)];
+    var L102 = [ new google.maps.LatLng(53.0, -8.0), new google.maps.LatLng(53.0, -8.0)];
     var P102 = new google.maps.Polyline({ path: L102, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P102.setMap(map);
 
 
-    var L103 = [ new google.maps.LatLng(25.0, 45.0), new google.maps.LatLng(26.1, 50.46)];
+    var L103 = [ new google.maps.LatLng(31.5, 34.75), new google.maps.LatLng(26.1, 50.46)];
     var P103 = new google.maps.Polyline({ path: L103, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P103.setMap(map);
 
 
-    var L104 = [ new google.maps.LatLng(35.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
+    var L104 = [ new google.maps.LatLng(20.0, 77.0), new google.maps.LatLng(19.08, 72.88)];
     var P104 = new google.maps.Polyline({ path: L104, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P104.setMap(map);
 
 
-    var L105 = [ new google.maps.LatLng(38.03, -109.78), new google.maps.LatLng(37.35, -121.96)];
+    var L105 = [ new google.maps.LatLng(-6.0, 71.5), new google.maps.LatLng(19.08, 72.88)];
     var P105 = new google.maps.Polyline({ path: L105, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P105.setMap(map);
 
 
-    var L106 = [ new google.maps.LatLng(62.0, 15.0), new google.maps.LatLng(59.25, 17.81)];
+    var L106 = [ new google.maps.LatLng(33.0, 44.0), new google.maps.LatLng(26.1, 50.46)];
     var P106 = new google.maps.Polyline({ path: L106, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P106.setMap(map);
 
 
-    var L107 = [ new google.maps.LatLng(42.8, 20.7), new google.maps.LatLng(45.43, 9.29)];
+    var L107 = [ new google.maps.LatLng(32.0, 53.0), new google.maps.LatLng(26.1, 50.46)];
     var P107 = new google.maps.Polyline({ path: L107, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P107.setMap(map);
 
 
-    var L108 = [ new google.maps.LatLng(12.0, -15.0), new google.maps.LatLng(45.43, 9.29)];
+    var L108 = [ new google.maps.LatLng(65.0, -18.0), new google.maps.LatLng(53.0, -8.0)];
     var P108 = new google.maps.Polyline({ path: L108, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P108.setMap(map);
 
 
-    var L109 = [ new google.maps.LatLng(-0.53, 166.92), new google.maps.LatLng(-33.86, 151.2)];
+    var L109 = [ new google.maps.LatLng(42.83, 12.83), new google.maps.LatLng(45.43, 9.29)];
     var P109 = new google.maps.Polyline({ path: L109, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P109.setMap(map);
 
 
-    var L110 = [ new google.maps.LatLng(53.0, 28.0), new google.maps.LatLng(59.25, 17.81)];
+    var L110 = [ new google.maps.LatLng(18.25, -77.5), new google.maps.LatLng(38.13, -78.45)];
     var P110 = new google.maps.Polyline({ path: L110, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P110.setMap(map);
 
 
-    var L111 = [ new google.maps.LatLng(49.0, 32.0), new google.maps.LatLng(59.25, 17.81)];
+    var L111 = [ new google.maps.LatLng(31.0, 36.0), new google.maps.LatLng(26.1, 50.46)];
     var P111 = new google.maps.Polyline({ path: L111, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P111.setMap(map);
 
 
-    var L112 = [ new google.maps.LatLng(15.0, 30.0), new google.maps.LatLng(26.1, 50.46)];
+    var L112 = [ new google.maps.LatLng(36.0, 138.0), new google.maps.LatLng(35.41, 139.42)];
     var P112 = new google.maps.Polyline({ path: L112, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P112.setMap(map);
 
 
-    var L113 = [ new google.maps.LatLng(-43.0, 67.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L113 = [ new google.maps.LatLng(1.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
     var P113 = new google.maps.Polyline({ path: L113, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P113.setMap(map);
 
 
-    var L114 = [ new google.maps.LatLng(32.0, 53.0), new google.maps.LatLng(26.1, 50.46)];
+    var L114 = [ new google.maps.LatLng(41.0, 75.0), new google.maps.LatLng(19.08, 72.88)];
     var P114 = new google.maps.Polyline({ path: L114, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P114.setMap(map);
 
 
-    var L115 = [ new google.maps.LatLng(-13.5, 34.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L115 = [ new google.maps.LatLng(13.0, 105.0), new google.maps.LatLng(1.37, 103.8)];
     var P115 = new google.maps.Polyline({ path: L115, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P115.setMap(map);
 
 
-    var L116 = [ new google.maps.LatLng(-13.58, -172.33), new google.maps.LatLng(-33.86, 151.2)];
+    var L116 = [ new google.maps.LatLng(1.42, 173.0), new google.maps.LatLng(-33.86, 151.2)];
     var P116 = new google.maps.Polyline({ path: L116, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P116.setMap(map);
 
 
-    var L117 = [ new google.maps.LatLng(19.0, -72.42), new google.maps.LatLng(38.13, -78.45)];
+    var L117 = [ new google.maps.LatLng(-12.17, 44.25), new google.maps.LatLng(-33.93, 18.42)];
     var P117 = new google.maps.Polyline({ path: L117, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P117.setMap(map);
 
 
-    var L118 = [ new google.maps.LatLng(44.58, -71.18), new google.maps.LatLng(45.5, -73.6)];
+    var L118 = [ new google.maps.LatLng(17.33, -62.75), new google.maps.LatLng(38.13, -78.45)];
     var P118 = new google.maps.Polyline({ path: L118, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P118.setMap(map);
 
 
-    var L119 = [ new google.maps.LatLng(47.0, 20.0), new google.maps.LatLng(45.43, 9.29)];
+    var L119 = [ new google.maps.LatLng(40.0, 127.0), new google.maps.LatLng(37.56, 126.98)];
     var P119 = new google.maps.Polyline({ path: L119, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P119.setMap(map);
 
 
-    var L120 = [ new google.maps.LatLng(42.47, -71.28), new google.maps.LatLng(45.5, -73.6)];
+    var L120 = [ new google.maps.LatLng(37.0, 127.5), new google.maps.LatLng(37.56, 126.98)];
     var P120 = new google.maps.Polyline({ path: L120, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P120.setMap(map);
 
 
-    var L121 = [ new google.maps.LatLng(40.5, 47.5), new google.maps.LatLng(26.1, 50.46)];
+    var L121 = [ new google.maps.LatLng(29.34, 47.66), new google.maps.LatLng(26.1, 50.46)];
     var P121 = new google.maps.Polyline({ path: L121, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P121.setMap(map);
 
 
-    var L122 = [ new google.maps.LatLng(46.0, 2.0), new google.maps.LatLng(48.86, 2.35)];
+    var L122 = [ new google.maps.LatLng(19.5, -80.5), new google.maps.LatLng(38.13, -78.45)];
     var P122 = new google.maps.Polyline({ path: L122, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P122.setMap(map);
 
 
-    var L123 = [ new google.maps.LatLng(41.0, 75.0), new google.maps.LatLng(19.08, 72.88)];
+    var L123 = [ new google.maps.LatLng(48.0, 68.0), new google.maps.LatLng(26.1, 50.46)];
     var P123 = new google.maps.Polyline({ path: L123, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P123.setMap(map);
 
 
-    var L124 = [ new google.maps.LatLng(44.0, 21.0), new google.maps.LatLng(45.43, 9.29)];
+    var L124 = [ new google.maps.LatLng(18.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
     var P124 = new google.maps.Polyline({ path: L124, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P124.setMap(map);
 
 
-    var L125 = [ new google.maps.LatLng(42.0, 19.0), new google.maps.LatLng(45.43, 9.29)];
+    var L125 = [ new google.maps.LatLng(33.83, 35.83), new google.maps.LatLng(26.1, 50.46)];
     var P125 = new google.maps.Polyline({ path: L125, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P125.setMap(map);
 
 
-    var L126 = [ new google.maps.LatLng(13.47, -16.57), new google.maps.LatLng(48.86, 2.35)];
+    var L126 = [ new google.maps.LatLng(13.88, -61.13), new google.maps.LatLng(38.13, -78.45)];
     var P126 = new google.maps.Polyline({ path: L126, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P126.setMap(map);
 
 
-    var L127 = [ new google.maps.LatLng(21.75, -71.58), new google.maps.LatLng(38.13, -78.45)];
+    var L127 = [ new google.maps.LatLng(47.17, 9.53), new google.maps.LatLng(45.43, 9.29)];
     var P127 = new google.maps.Polyline({ path: L127, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P127.setMap(map);
 
 
-    var L128 = [ new google.maps.LatLng(53.0, -8.0), new google.maps.LatLng(53.0, -8.0)];
+    var L128 = [ new google.maps.LatLng(7.0, 81.0), new google.maps.LatLng(19.08, 72.88)];
     var P128 = new google.maps.Polyline({ path: L128, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P128.setMap(map);
 
 
-    var L129 = [ new google.maps.LatLng(15.2, 145.75), new google.maps.LatLng(35.41, 139.42)];
+    var L129 = [ new google.maps.LatLng(6.5, -9.5), new google.maps.LatLng(45.43, 9.29)];
     var P129 = new google.maps.Polyline({ path: L129, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P129.setMap(map);
 
 
-    var L130 = [ new google.maps.LatLng(-15.0, -140.0), new google.maps.LatLng(37.35, -121.96)];
+    var L130 = [ new google.maps.LatLng(-29.5, 28.5), new google.maps.LatLng(1.37, 103.8)];
     var P130 = new google.maps.Polyline({ path: L130, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P130.setMap(map);
 
 
-    var L131 = [ new google.maps.LatLng(48.67, 19.5), new google.maps.LatLng(50.0, 8.0)];
+    var L131 = [ new google.maps.LatLng(56.0, 24.0), new google.maps.LatLng(59.25, 17.81)];
     var P131 = new google.maps.Polyline({ path: L131, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P131.setMap(map);
 
 
-    var L132 = [ new google.maps.LatLng(15.42, -61.33), new google.maps.LatLng(38.13, -78.45)];
+    var L132 = [ new google.maps.LatLng(49.75, 6.17), new google.maps.LatLng(50.0, 8.0)];
     var P132 = new google.maps.Polyline({ path: L132, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P132.setMap(map);
 
 
-    var L133 = [ new google.maps.LatLng(45.45, -98.43), new google.maps.LatLng(39.96, -83.0)];
+    var L133 = [ new google.maps.LatLng(57.0, 25.0), new google.maps.LatLng(59.25, 17.81)];
     var P133 = new google.maps.Polyline({ path: L133, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P133.setMap(map);
 
 
-    var L134 = [ new google.maps.LatLng(41.0, 20.0), new google.maps.LatLng(45.43, 9.29)];
+    var L134 = [ new google.maps.LatLng(25.0, 17.0), new google.maps.LatLng(45.43, 9.29)];
     var P134 = new google.maps.Polyline({ path: L134, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P134.setMap(map);
 
 
-    var L135 = [ new google.maps.LatLng(38.85, -77.04), new google.maps.LatLng(38.13, -78.45)];
+    var L135 = [ new google.maps.LatLng(32.0, -5.0), new google.maps.LatLng(45.43, 9.29)];
     var P135 = new google.maps.Polyline({ path: L135, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P135.setMap(map);
 
 
-    var L136 = [ new google.maps.LatLng(47.17, 9.53), new google.maps.LatLng(45.43, 9.29)];
+    var L136 = [ new google.maps.LatLng(43.73, 7.4), new google.maps.LatLng(45.43, 9.29)];
     var P136 = new google.maps.Polyline({ path: L136, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P136.setMap(map);
 
 
-    var L137 = [ new google.maps.LatLng(17.05, -61.8), new google.maps.LatLng(38.13, -78.45)];
+    var L137 = [ new google.maps.LatLng(47.0, 29.0), new google.maps.LatLng(45.43, 9.29)];
     var P137 = new google.maps.Polyline({ path: L137, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P137.setMap(map);
 
 
-    var L138 = [ new google.maps.LatLng(11.5, 43.0), new google.maps.LatLng(26.1, 50.46)];
+    var L138 = [ new google.maps.LatLng(42.0, 19.0), new google.maps.LatLng(45.43, 9.29)];
     var P138 = new google.maps.Polyline({ path: L138, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P138.setMap(map);
 
 
-    var L139 = [ new google.maps.LatLng(16.25, -61.58), new google.maps.LatLng(38.13, -78.45)];
+    var L139 = [ new google.maps.LatLng(18.07, -63.13), new google.maps.LatLng(38.13, -78.45)];
     var P139 = new google.maps.Polyline({ path: L139, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P139.setMap(map);
 
 
-    var L140 = [ new google.maps.LatLng(13.83, -88.92), new google.maps.LatLng(38.13, -78.45)];
+    var L140 = [ new google.maps.LatLng(-20.0, 47.0), new google.maps.LatLng(-33.93, 18.42)];
     var P140 = new google.maps.Polyline({ path: L140, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P140.setMap(map);
 
 
-    var L141 = [ new google.maps.LatLng(16.0, 106.0), new google.maps.LatLng(22.27, 114.16)];
+    var L141 = [ new google.maps.LatLng(9.0, 168.0), new google.maps.LatLng(35.41, 139.42)];
     var P141 = new google.maps.Polyline({ path: L141, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P141.setMap(map);
 
 
-    var L142 = [ new google.maps.LatLng(1.0, 32.0), new google.maps.LatLng(26.1, 50.46)];
+    var L142 = [ new google.maps.LatLng(41.83, 22.0), new google.maps.LatLng(45.43, 9.29)];
     var P142 = new google.maps.Polyline({ path: L142, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P142.setMap(map);
 
 
-    var L143 = [ new google.maps.LatLng(-5.0, 120.0), new google.maps.LatLng(1.37, 103.8)];
+    var L143 = [ new google.maps.LatLng(17.0, -4.0), new google.maps.LatLng(45.43, 9.29)];
     var P143 = new google.maps.Polyline({ path: L143, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P143.setMap(map);
 
 
-    var L144 = [ new google.maps.LatLng(43.57, -116.22), new google.maps.LatLng(46.15, -123.88)];
+    var L144 = [ new google.maps.LatLng(22.0, 98.0), new google.maps.LatLng(22.27, 114.16)];
     var P144 = new google.maps.Polyline({ path: L144, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P144.setMap(map);
 
 
-    var L145 = [ new google.maps.LatLng(48.8, -122.53), new google.maps.LatLng(46.15, -123.88)];
+    var L145 = [ new google.maps.LatLng(46.0, 105.0), new google.maps.LatLng(37.56, 126.98)];
     var P145 = new google.maps.Polyline({ path: L145, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P145.setMap(map);
 
 
-    var L146 = [ new google.maps.LatLng(12.5, -69.97), new google.maps.LatLng(38.13, -78.45)];
+    var L146 = [ new google.maps.LatLng(22.17, 113.55), new google.maps.LatLng(22.27, 114.16)];
     var P146 = new google.maps.Polyline({ path: L146, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P146.setMap(map);
 
 
-    var L147 = [ new google.maps.LatLng(30.0, 70.0), new google.maps.LatLng(19.08, 72.88)];
+    var L147 = [ new google.maps.LatLng(15.2, 145.75), new google.maps.LatLng(35.41, 139.42)];
     var P147 = new google.maps.Polyline({ path: L147, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P147.setMap(map);
 
 
-    var L148 = [ new google.maps.LatLng(-4.58, 55.67), new google.maps.LatLng(19.08, 72.88)];
+    var L148 = [ new google.maps.LatLng(14.67, -61.0), new google.maps.LatLng(38.13, -78.45)];
     var P148 = new google.maps.Polyline({ path: L148, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P148.setMap(map);
 
 
-    var L149 = [ new google.maps.LatLng(51.0, 9.0), new google.maps.LatLng(50.0, 8.0)];
+    var L149 = [ new google.maps.LatLng(20.0, -12.0), new google.maps.LatLng(45.43, 9.29)];
     var P149 = new google.maps.Polyline({ path: L149, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P149.setMap(map);
 
 
-    var L150 = [ new google.maps.LatLng(14.81, -67.97), new google.maps.LatLng(38.13, -78.45)];
+    var L150 = [ new google.maps.LatLng(16.75, -62.2), new google.maps.LatLng(38.13, -78.45)];
     var P150 = new google.maps.Polyline({ path: L150, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P150.setMap(map);
 
 
-    var L151 = [ new google.maps.LatLng(-27.0, 133.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L151 = [ new google.maps.LatLng(35.83, 14.58), new google.maps.LatLng(45.43, 9.29)];
     var P151 = new google.maps.Polyline({ path: L151, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P151.setMap(map);
 
 
-    var L152 = [ new google.maps.LatLng(8.0, -66.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L152 = [ new google.maps.LatLng(-20.28, 57.55), new google.maps.LatLng(-33.93, 18.42)];
     var P152 = new google.maps.Polyline({ path: L152, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P152.setMap(map);
 
 
-    var L153 = [ new google.maps.LatLng(35.0, 105.0), new google.maps.LatLng(22.27, 114.16)];
+    var L153 = [ new google.maps.LatLng(3.25, 73.0), new google.maps.LatLng(19.08, 72.88)];
     var P153 = new google.maps.Polyline({ path: L153, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P153.setMap(map);
 
 
-    var L154 = [ new google.maps.LatLng(9.0, 168.0), new google.maps.LatLng(35.41, 139.42)];
+    var L154 = [ new google.maps.LatLng(-13.5, 34.0), new google.maps.LatLng(-33.93, 18.42)];
     var P154 = new google.maps.Polyline({ path: L154, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P154.setMap(map);
 
 
-    var L155 = [ new google.maps.LatLng(44.25, -88.52), new google.maps.LatLng(39.96, -83.0)];
+    var L155 = [ new google.maps.LatLng(23.0, -102.0), new google.maps.LatLng(37.35, -121.96)];
     var P155 = new google.maps.Polyline({ path: L155, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P155.setMap(map);
 
 
-    var L156 = [ new google.maps.LatLng(1.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
+    var L156 = [ new google.maps.LatLng(2.5, 112.5), new google.maps.LatLng(1.37, 103.8)];
     var P156 = new google.maps.Polyline({ path: L156, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P156.setMap(map);
 
 
-    var L157 = [ new google.maps.LatLng(32.33, -64.75), new google.maps.LatLng(38.13, -78.45)];
+    var L157 = [ new google.maps.LatLng(-18.25, 35.0), new google.maps.LatLng(-33.93, 18.42)];
     var P157 = new google.maps.Polyline({ path: L157, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P157.setMap(map);
 
 
-    var L158 = [ new google.maps.LatLng(-12.5, 96.83), new google.maps.LatLng(1.37, 103.8)];
+    var L158 = [ new google.maps.LatLng(-22.0, 17.0), new google.maps.LatLng(53.0, -8.0)];
     var P158 = new google.maps.Polyline({ path: L158, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P158.setMap(map);
 
 
-    var L159 = [ new google.maps.LatLng(13.88, -61.13), new google.maps.LatLng(38.13, -78.45)];
+    var L159 = [ new google.maps.LatLng(-21.5, 165.5), new google.maps.LatLng(-33.86, 151.2)];
     var P159 = new google.maps.Polyline({ path: L159, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P159.setMap(map);
 
 
-    var L160 = [ new google.maps.LatLng(36.18, -5.37), new google.maps.LatLng(48.86, 2.35)];
+    var L160 = [ new google.maps.LatLng(16.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
     var P160 = new google.maps.Polyline({ path: L160, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P160.setMap(map);
 
 
-    var L161 = [ new google.maps.LatLng(3.25, 73.0), new google.maps.LatLng(19.08, 72.88)];
+    var L161 = [ new google.maps.LatLng(-29.03, 167.95), new google.maps.LatLng(-33.86, 151.2)];
     var P161 = new google.maps.Polyline({ path: L161, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P161.setMap(map);
 
 
-    var L162 = [ new google.maps.LatLng(42.58, -99.98), new google.maps.LatLng(39.96, -83.0)];
+    var L162 = [ new google.maps.LatLng(10.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
     var P162 = new google.maps.Polyline({ path: L162, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P162.setMap(map);
 
 
-    var L163 = [ new google.maps.LatLng(32.42, -99.68), new google.maps.LatLng(39.96, -83.0)];
+    var L163 = [ new google.maps.LatLng(13.0, -85.0), new google.maps.LatLng(38.13, -78.45)];
     var P163 = new google.maps.Polyline({ path: L163, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P163.setMap(map);
 
 
-    var L164 = [ new google.maps.LatLng(16.75, -62.2), new google.maps.LatLng(38.13, -78.45)];
+    var L164 = [ new google.maps.LatLng(52.5, 5.75), new google.maps.LatLng(53.0, -8.0)];
     var P164 = new google.maps.Polyline({ path: L164, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P164.setMap(map);
 
 
-    var L165 = [ new google.maps.LatLng(42.0, 43.5), new google.maps.LatLng(26.1, 50.46)];
+    var L165 = [ new google.maps.LatLng(62.0, 10.0), new google.maps.LatLng(59.25, 17.81)];
     var P165 = new google.maps.Polyline({ path: L165, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P165.setMap(map);
 
 
-    var L166 = [ new google.maps.LatLng(-29.5, 28.5), new google.maps.LatLng(1.37, 103.8)];
+    var L166 = [ new google.maps.LatLng(28.0, 84.0), new google.maps.LatLng(19.08, 72.88)];
     var P166 = new google.maps.Polyline({ path: L166, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P166.setMap(map);
 
 
-    var L167 = [ new google.maps.LatLng(29.34, 47.66), new google.maps.LatLng(26.1, 50.46)];
+    var L167 = [ new google.maps.LatLng(-0.53, 166.92), new google.maps.LatLng(-33.86, 151.2)];
     var P167 = new google.maps.Polyline({ path: L167, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P167.setMap(map);
 
 
-    var L168 = [ new google.maps.LatLng(42.5, -107.5), new google.maps.LatLng(37.35, -121.96)];
+    var L168 = [ new google.maps.LatLng(-19.03, -169.87), new google.maps.LatLng(-33.86, 151.2)];
     var P168 = new google.maps.Polyline({ path: L168, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P168.setMap(map);
 
 
-    var L169 = [ new google.maps.LatLng(35.83, 14.58), new google.maps.LatLng(45.43, 9.29)];
+    var L169 = [ new google.maps.LatLng(-41.0, 174.0), new google.maps.LatLng(-33.86, 151.2)];
     var P169 = new google.maps.Polyline({ path: L169, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P169.setMap(map);
 
 
-    var L170 = [ new google.maps.LatLng(39.13, -75.47), new google.maps.LatLng(38.13, -78.45)];
+    var L170 = [ new google.maps.LatLng(21.0, 57.0), new google.maps.LatLng(26.1, 50.46)];
     var P170 = new google.maps.Polyline({ path: L170, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P170.setMap(map);
 
 
-    var L171 = [ new google.maps.LatLng(15.5, -90.25), new google.maps.LatLng(38.13, -78.45)];
+    var L171 = [ new google.maps.LatLng(9.0, -80.0), new google.maps.LatLng(38.13, -78.45)];
     var P171 = new google.maps.Polyline({ path: L171, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P171.setMap(map);
 
 
-    var L172 = [ new google.maps.LatLng(11.0, -61.0), new google.maps.LatLng(38.13, -78.45)];
+    var L172 = [ new google.maps.LatLng(-10.0, -76.0), new google.maps.LatLng(-23.34, -46.38)];
     var P172 = new google.maps.Polyline({ path: L172, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P172.setMap(map);
 
 
-    var L173 = [ new google.maps.LatLng(39.0, 71.0), new google.maps.LatLng(19.08, 72.88)];
+    var L173 = [ new google.maps.LatLng(-15.0, -140.0), new google.maps.LatLng(37.35, -121.96)];
     var P173 = new google.maps.Polyline({ path: L173, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P173.setMap(map);
 
 
-    var L174 = [ new google.maps.LatLng(1.0, 7.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L174 = [ new google.maps.LatLng(-6.0, 147.0), new google.maps.LatLng(-33.86, 151.2)];
     var P174 = new google.maps.Polyline({ path: L174, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P174.setMap(map);
 
 
-    var L175 = [ new google.maps.LatLng(35.05, -106.6), new google.maps.LatLng(37.35, -121.96)];
+    var L175 = [ new google.maps.LatLng(13.0, 122.0), new google.maps.LatLng(22.27, 114.16)];
     var P175 = new google.maps.Polyline({ path: L175, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P175.setMap(map);
 
 
-    var L176 = [ new google.maps.LatLng(46.0, 25.0), new google.maps.LatLng(45.43, 9.29)];
+    var L176 = [ new google.maps.LatLng(30.0, 70.0), new google.maps.LatLng(19.08, 72.88)];
     var P176 = new google.maps.Polyline({ path: L176, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P176.setMap(map);
 
 
-    var L177 = [ new google.maps.LatLng(21.0, 57.0), new google.maps.LatLng(26.1, 50.46)];
+    var L177 = [ new google.maps.LatLng(52.0, 20.0), new google.maps.LatLng(59.25, 17.81)];
     var P177 = new google.maps.Polyline({ path: L177, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P177.setMap(map);
 
 
-    var L178 = [ new google.maps.LatLng(42.5, 1.5), new google.maps.LatLng(45.43, 9.29)];
+    var L178 = [ new google.maps.LatLng(46.83, -56.33), new google.maps.LatLng(45.5, -73.6)];
     var P178 = new google.maps.Polyline({ path: L178, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P178.setMap(map);
 
 
-    var L179 = [ new google.maps.LatLng(4.0, -72.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L179 = [ new google.maps.LatLng(18.25, -66.5), new google.maps.LatLng(38.13, -78.45)];
     var P179 = new google.maps.Polyline({ path: L179, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P179.setMap(map);
 
 
-    var L180 = [ new google.maps.LatLng(41.9, 12.45), new google.maps.LatLng(45.43, 9.29)];
+    var L180 = [ new google.maps.LatLng(32.0, 35.25), new google.maps.LatLng(26.1, 50.46)];
     var P180 = new google.maps.Polyline({ path: L180, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P180.setMap(map);
 
 
-    var L181 = [ new google.maps.LatLng(15.0, 19.0), new google.maps.LatLng(26.1, 50.46)];
+    var L181 = [ new google.maps.LatLng(39.5, -8.0), new google.maps.LatLng(48.86, 2.35)];
     var P181 = new google.maps.Polyline({ path: L181, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P181.setMap(map);
 
 
-    var L182 = [ new google.maps.LatLng(38.82, -92.22), new google.maps.LatLng(39.96, -83.0)];
+    var L182 = [ new google.maps.LatLng(7.5, 134.5), new google.maps.LatLng(22.27, 114.16)];
     var P182 = new google.maps.Polyline({ path: L182, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P182.setMap(map);
 
 
-    var L183 = [ new google.maps.LatLng(48.0, 68.0), new google.maps.LatLng(26.1, 50.46)];
+    var L183 = [ new google.maps.LatLng(-23.0, -58.0), new google.maps.LatLng(-23.34, -46.38)];
     var P183 = new google.maps.Polyline({ path: L183, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P183.setMap(map);
 
 
-    var L184 = [ new google.maps.LatLng(40.0, 60.0), new google.maps.LatLng(26.1, 50.46)];
+    var L184 = [ new google.maps.LatLng(25.5, 51.25), new google.maps.LatLng(26.1, 50.46)];
     var P184 = new google.maps.Polyline({ path: L184, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P184.setMap(map);
 
 
-    var L185 = [ new google.maps.LatLng(46.0, 15.0), new google.maps.LatLng(45.43, 9.29)];
+    var L185 = [ new google.maps.LatLng(-21.1, 55.6), new google.maps.LatLng(-33.93, 18.42)];
     var P185 = new google.maps.Polyline({ path: L185, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P185.setMap(map);
 
 
-    var L186 = [ new google.maps.LatLng(47.33, 13.33), new google.maps.LatLng(45.43, 9.29)];
+    var L186 = [ new google.maps.LatLng(46.0, 25.0), new google.maps.LatLng(45.43, 9.29)];
     var P186 = new google.maps.Polyline({ path: L186, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P186.setMap(map);
 
 
-    var L187 = [ new google.maps.LatLng(15.0, -86.5), new google.maps.LatLng(38.13, -78.45)];
+    var L187 = [ new google.maps.LatLng(44.0, 21.0), new google.maps.LatLng(45.43, 9.29)];
     var P187 = new google.maps.Polyline({ path: L187, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P187.setMap(map);
 
 
-    var L188 = [ new google.maps.LatLng(18.07, -63.13), new google.maps.LatLng(38.13, -78.45)];
+    var L188 = [ new google.maps.LatLng(60.0, 100.0), new google.maps.LatLng(37.56, 126.98)];
     var P188 = new google.maps.Polyline({ path: L188, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P188.setMap(map);
 
 
-    var L189 = [ new google.maps.LatLng(27.0, 30.0), new google.maps.LatLng(26.1, 50.46)];
+    var L189 = [ new google.maps.LatLng(-2.0, 30.0), new google.maps.LatLng(-33.93, 18.42)];
     var P189 = new google.maps.Polyline({ path: L189, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P189.setMap(map);
 
 
-    var L190 = [ new google.maps.LatLng(-6.0, 35.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L190 = [ new google.maps.LatLng(25.0, 45.0), new google.maps.LatLng(26.1, 50.46)];
     var P190 = new google.maps.Polyline({ path: L190, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P190.setMap(map);
 
@@ -2226,532 +2226,532 @@ ProcessCable("CBUS", "4.80000000000e+002", "http://www.cwbda.com/", "", "1.60000
     P191.setMap(map);
 
 
-    var L192 = [ new google.maps.LatLng(18.33, -64.83), new google.maps.LatLng(38.13, -78.45)];
+    var L192 = [ new google.maps.LatLng(-4.58, 55.67), new google.maps.LatLng(19.08, 72.88)];
     var P192 = new google.maps.Polyline({ path: L192, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P192.setMap(map);
 
 
-    var L193 = [ new google.maps.LatLng(17.92, -62.94), new google.maps.LatLng(38.13, -78.45)];
+    var L193 = [ new google.maps.LatLng(15.0, 30.0), new google.maps.LatLng(26.1, 50.46)];
     var P193 = new google.maps.Polyline({ path: L193, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P193.setMap(map);
 
 
-    var L194 = [ new google.maps.LatLng(72.0, -40.0), new google.maps.LatLng(53.0, -8.0)];
+    var L194 = [ new google.maps.LatLng(62.0, 15.0), new google.maps.LatLng(59.25, 17.81)];
     var P194 = new google.maps.Polyline({ path: L194, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P194.setMap(map);
 
 
-    var L195 = [ new google.maps.LatLng(44.32, -69.8), new google.maps.LatLng(45.5, -73.6)];
+    var L195 = [ new google.maps.LatLng(1.37, 103.8), new google.maps.LatLng(1.37, 103.8)];
     var P195 = new google.maps.Polyline({ path: L195, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P195.setMap(map);
 
 
-    var L196 = [ new google.maps.LatLng(42.83, 12.83), new google.maps.LatLng(45.43, 9.29)];
+    var L196 = [ new google.maps.LatLng(-15.93, -5.7), new google.maps.LatLng(-33.93, 18.42)];
     var P196 = new google.maps.Polyline({ path: L196, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P196.setMap(map);
 
 
-    var L197 = [ new google.maps.LatLng(9.0, -80.0), new google.maps.LatLng(38.13, -78.45)];
+    var L197 = [ new google.maps.LatLng(46.0, 15.0), new google.maps.LatLng(45.43, 9.29)];
     var P197 = new google.maps.Polyline({ path: L197, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P197.setMap(map);
 
 
-    var L198 = [ new google.maps.LatLng(-33.0, -56.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L198 = [ new google.maps.LatLng(78.0, 20.0), new google.maps.LatLng(59.25, 17.81)];
     var P198 = new google.maps.Polyline({ path: L198, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P198.setMap(map);
 
 
-    var L199 = [ new google.maps.LatLng(41.17, -71.58), new google.maps.LatLng(45.5, -73.6)];
+    var L199 = [ new google.maps.LatLng(48.67, 19.5), new google.maps.LatLng(50.0, 8.0)];
     var P199 = new google.maps.Polyline({ path: L199, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P199.setMap(map);
 
 
-    var L200 = [ new google.maps.LatLng(32.17, -110.88), new google.maps.LatLng(37.35, -121.96)];
+    var L200 = [ new google.maps.LatLng(8.5, -11.5), new google.maps.LatLng(45.43, 9.29)];
     var P200 = new google.maps.Polyline({ path: L200, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P200.setMap(map);
 
 
-    var L201 = [ new google.maps.LatLng(46.0, 105.0), new google.maps.LatLng(37.56, 126.98)];
+    var L201 = [ new google.maps.LatLng(43.77, 12.42), new google.maps.LatLng(45.43, 9.29)];
     var P201 = new google.maps.Polyline({ path: L201, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P201.setMap(map);
 
 
-    var L202 = [ new google.maps.LatLng(33.65, -88.45), new google.maps.LatLng(39.96, -83.0)];
+    var L202 = [ new google.maps.LatLng(14.0, -14.0), new google.maps.LatLng(45.43, 9.29)];
     var P202 = new google.maps.Polyline({ path: L202, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P202.setMap(map);
 
 
-    var L203 = [ new google.maps.LatLng(14.0, -14.0), new google.maps.LatLng(45.43, 9.29)];
+    var L203 = [ new google.maps.LatLng(10.0, 49.0), new google.maps.LatLng(26.1, 50.46)];
     var P203 = new google.maps.Polyline({ path: L203, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P203.setMap(map);
 
 
-    var L204 = [ new google.maps.LatLng(31.5, 34.75), new google.maps.LatLng(26.1, 50.46)];
+    var L204 = [ new google.maps.LatLng(4.0, -56.0), new google.maps.LatLng(-23.34, -46.38)];
     var P204 = new google.maps.Polyline({ path: L204, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P204.setMap(map);
 
 
-    var L205 = [ new google.maps.LatLng(-20.0, -175.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L205 = [ new google.maps.LatLng(7.85, 25.19), new google.maps.LatLng(26.1, 50.46)];
     var P205 = new google.maps.Polyline({ path: L205, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P205.setMap(map);
 
 
-    var L206 = [ new google.maps.LatLng(25.5, 51.25), new google.maps.LatLng(26.1, 50.46)];
+    var L206 = [ new google.maps.LatLng(18.03, -63.13), new google.maps.LatLng(38.13, -78.45)];
     var P206 = new google.maps.Polyline({ path: L206, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P206.setMap(map);
 
 
-    var L207 = [ new google.maps.LatLng(43.0, 25.0), new google.maps.LatLng(45.43, 9.29)];
+    var L207 = [ new google.maps.LatLng(1.0, 7.0), new google.maps.LatLng(-33.93, 18.42)];
     var P207 = new google.maps.Polyline({ path: L207, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P207.setMap(map);
 
 
-    var L208 = [ new google.maps.LatLng(-15.93, -5.7), new google.maps.LatLng(-33.93, 18.42)];
+    var L208 = [ new google.maps.LatLng(13.83, -88.92), new google.maps.LatLng(38.13, -78.45)];
     var P208 = new google.maps.Polyline({ path: L208, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P208.setMap(map);
 
 
-    var L209 = [ new google.maps.LatLng(39.0, 35.0), new google.maps.LatLng(26.1, 50.46)];
+    var L209 = [ new google.maps.LatLng(35.0, 38.0), new google.maps.LatLng(26.1, 50.46)];
     var P209 = new google.maps.Polyline({ path: L209, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P209.setMap(map);
 
 
-    var L210 = [ new google.maps.LatLng(2.0, 10.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L210 = [ new google.maps.LatLng(-26.5, 31.5), new google.maps.LatLng(1.37, 103.8)];
     var P210 = new google.maps.Polyline({ path: L210, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P210.setMap(map);
 
 
-    var L211 = [ new google.maps.LatLng(17.0, -4.0), new google.maps.LatLng(45.43, 9.29)];
+    var L211 = [ new google.maps.LatLng(21.75, -71.58), new google.maps.LatLng(38.13, -78.45)];
     var P211 = new google.maps.Polyline({ path: L211, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P211.setMap(map);
 
 
-    var L212 = [ new google.maps.LatLng(56.0, 10.0), new google.maps.LatLng(59.25, 17.81)];
+    var L212 = [ new google.maps.LatLng(15.0, 19.0), new google.maps.LatLng(26.1, 50.46)];
     var P212 = new google.maps.Polyline({ path: L212, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P212.setMap(map);
 
 
-    var L213 = [ new google.maps.LatLng(52.0, 20.0), new google.maps.LatLng(59.25, 17.81)];
+    var L213 = [ new google.maps.LatLng(-43.0, 67.0), new google.maps.LatLng(-33.93, 18.42)];
     var P213 = new google.maps.Polyline({ path: L213, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P213.setMap(map);
 
 
-    var L214 = [ new google.maps.LatLng(19.0, -70.67), new google.maps.LatLng(38.13, -78.45)];
+    var L214 = [ new google.maps.LatLng(8.0, 1.17), new google.maps.LatLng(45.43, 9.29)];
     var P214 = new google.maps.Polyline({ path: L214, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P214.setMap(map);
 
 
-    var L215 = [ new google.maps.LatLng(39.52, -105.35), new google.maps.LatLng(37.35, -121.96)];
+    var L215 = [ new google.maps.LatLng(15.0, 100.0), new google.maps.LatLng(1.37, 103.8)];
     var P215 = new google.maps.Polyline({ path: L215, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P215.setMap(map);
 
 
-    var L216 = [ new google.maps.LatLng(-10.5, 105.67), new google.maps.LatLng(1.37, 103.8)];
+    var L216 = [ new google.maps.LatLng(39.0, 71.0), new google.maps.LatLng(19.08, 72.88)];
     var P216 = new google.maps.Polyline({ path: L216, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P216.setMap(map);
 
 
-    var L217 = [ new google.maps.LatLng(19.5, -80.5), new google.maps.LatLng(38.13, -78.45)];
+    var L217 = [ new google.maps.LatLng(-9.0, -172.0), new google.maps.LatLng(-33.86, 151.2)];
     var P217 = new google.maps.Polyline({ path: L217, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P217.setMap(map);
 
 
-    var L218 = [ new google.maps.LatLng(2.5, 112.5), new google.maps.LatLng(1.37, 103.8)];
+    var L218 = [ new google.maps.LatLng(40.0, 60.0), new google.maps.LatLng(26.1, 50.46)];
     var P218 = new google.maps.Polyline({ path: L218, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P218.setMap(map);
 
 
-    var L219 = [ new google.maps.LatLng(46.83, -56.33), new google.maps.LatLng(45.5, -73.6)];
+    var L219 = [ new google.maps.LatLng(34.0, 9.0), new google.maps.LatLng(45.43, 9.29)];
     var P219 = new google.maps.Polyline({ path: L219, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P219.setMap(map);
 
 
-    var L220 = [ new google.maps.LatLng(-1.0, 11.75), new google.maps.LatLng(-33.93, 18.42)];
+    var L220 = [ new google.maps.LatLng(-20.0, -175.0), new google.maps.LatLng(-33.86, 151.2)];
     var P220 = new google.maps.Polyline({ path: L220, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P220.setMap(map);
 
 
-    var L221 = [ new google.maps.LatLng(-17.0, -65.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L221 = [ new google.maps.LatLng(39.0, 35.0), new google.maps.LatLng(26.1, 50.46)];
     var P221 = new google.maps.Polyline({ path: L221, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P221.setMap(map);
 
 
-    var L222 = [ new google.maps.LatLng(-41.0, 174.0), new google.maps.LatLng(-33.86, 151.2)];
+    var L222 = [ new google.maps.LatLng(11.0, -61.0), new google.maps.LatLng(38.13, -78.45)];
     var P222 = new google.maps.Polyline({ path: L222, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P222.setMap(map);
 
 
-    var L223 = [ new google.maps.LatLng(42.75, -73.8), new google.maps.LatLng(45.5, -73.6)];
+    var L223 = [ new google.maps.LatLng(-8.0, 178.0), new google.maps.LatLng(-33.86, 151.2)];
     var P223 = new google.maps.Polyline({ path: L223, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P223.setMap(map);
 
 
-    var L224 = [ new google.maps.LatLng(-12.5, 18.5), new google.maps.LatLng(53.0, -8.0)];
+    var L224 = [ new google.maps.LatLng(23.5, 121.0), new google.maps.LatLng(22.27, 114.16)];
     var P224 = new google.maps.Polyline({ path: L224, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P224.setMap(map);
 
 
-    var L225 = [ new google.maps.LatLng(4.0, -53.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L225 = [ new google.maps.LatLng(-6.0, 35.0), new google.maps.LatLng(-33.93, 18.42)];
     var P225 = new google.maps.Polyline({ path: L225, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P225.setMap(map);
 
 
-    var L226 = [ new google.maps.LatLng(45.8, -108.53), new google.maps.LatLng(46.15, -123.88)];
+    var L226 = [ new google.maps.LatLng(49.0, 32.0), new google.maps.LatLng(59.25, 17.81)];
     var P226 = new google.maps.Polyline({ path: L226, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P226.setMap(map);
 
 
-    var L227 = [ new google.maps.LatLng(17.33, -62.75), new google.maps.LatLng(38.13, -78.45)];
+    var L227 = [ new google.maps.LatLng(1.0, 32.0), new google.maps.LatLng(26.1, 50.46)];
     var P227 = new google.maps.Polyline({ path: L227, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P227.setMap(map);
 
 
-    var L228 = [ new google.maps.LatLng(-1.0, 15.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L228 = [ new google.maps.LatLng(19.28, 166.6), new google.maps.LatLng(35.41, 139.42)];
     var P228 = new google.maps.Polyline({ path: L228, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P228.setMap(map);
 
 
-    var L229 = [ new google.maps.LatLng(18.25, -63.17), new google.maps.LatLng(38.13, -78.45)];
+    var L229 = [ new google.maps.LatLng(38.0, -97.0), new google.maps.LatLng(39.96, -83.0)];
     var P229 = new google.maps.Polyline({ path: L229, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P229.setMap(map);
 
 
-    var L230 = [ new google.maps.LatLng(-51.75, -59.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L230 = [ new google.maps.LatLng(-33.0, -56.0), new google.maps.LatLng(-23.34, -46.38)];
     var P230 = new google.maps.Polyline({ path: L230, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P230.setMap(map);
 
 
-    var L231 = [ new google.maps.LatLng(13.47, 144.78), new google.maps.LatLng(35.41, 139.42)];
+    var L231 = [ new google.maps.LatLng(41.0, 64.0), new google.maps.LatLng(26.1, 50.46)];
     var P231 = new google.maps.Polyline({ path: L231, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P231.setMap(map);
 
 
-    var L232 = [ new google.maps.LatLng(40.0, -4.0), new google.maps.LatLng(48.86, 2.35)];
+    var L232 = [ new google.maps.LatLng(41.9, 12.45), new google.maps.LatLng(45.43, 9.29)];
     var P232 = new google.maps.Polyline({ path: L232, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P232.setMap(map);
 
 
-    var L233 = [ new google.maps.LatLng(60.0, 100.0), new google.maps.LatLng(37.56, 126.98)];
+    var L233 = [ new google.maps.LatLng(13.25, -61.2), new google.maps.LatLng(38.13, -78.45)];
     var P233 = new google.maps.Polyline({ path: L233, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P233.setMap(map);
 
 
-    var L234 = [ new google.maps.LatLng(38.13, -78.45), new google.maps.LatLng(38.13, -78.45)];
+    var L234 = [ new google.maps.LatLng(8.0, -66.0), new google.maps.LatLng(-23.34, -46.38)];
     var P234 = new google.maps.Polyline({ path: L234, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P234.setMap(map);
 
 
-    var L235 = [ new google.maps.LatLng(40.0, 127.0), new google.maps.LatLng(37.56, 126.98)];
+    var L235 = [ new google.maps.LatLng(18.5, -64.5), new google.maps.LatLng(38.13, -78.45)];
     var P235 = new google.maps.Polyline({ path: L235, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P235.setMap(map);
 
 
-    var L236 = [ new google.maps.LatLng(40.78, -91.12), new google.maps.LatLng(39.96, -83.0)];
+    var L236 = [ new google.maps.LatLng(18.33, -64.83), new google.maps.LatLng(38.13, -78.45)];
     var P236 = new google.maps.Polyline({ path: L236, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P236.setMap(map);
 
 
-    var L237 = [ new google.maps.LatLng(15.0, 48.0), new google.maps.LatLng(26.1, 50.46)];
+    var L237 = [ new google.maps.LatLng(16.0, 106.0), new google.maps.LatLng(22.27, 114.16)];
     var P237 = new google.maps.Polyline({ path: L237, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P237.setMap(map);
 
 
-    var L238 = [ new google.maps.LatLng(43.77, 12.42), new google.maps.LatLng(45.43, 9.29)];
+    var L238 = [ new google.maps.LatLng(-16.0, 167.0), new google.maps.LatLng(-33.86, 151.2)];
     var P238 = new google.maps.Polyline({ path: L238, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P238.setMap(map);
 
 
-    var L239 = [ new google.maps.LatLng(11.0, -10.0), new google.maps.LatLng(45.43, 9.29)];
+    var L239 = [ new google.maps.LatLng(-13.3, -176.2), new google.maps.LatLng(-33.86, 151.2)];
     var P239 = new google.maps.Polyline({ path: L239, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P239.setMap(map);
 
 
-    var L240 = [ new google.maps.LatLng(39.21, -82.23), new google.maps.LatLng(39.96, -83.0)];
+    var L240 = [ new google.maps.LatLng(-13.58, -172.33), new google.maps.LatLng(-33.86, 151.2)];
     var P240 = new google.maps.Polyline({ path: L240, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P240.setMap(map);
 
 
-    var L241 = [ new google.maps.LatLng(-23.0, -58.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L241 = [ new google.maps.LatLng(42.8, 20.7), new google.maps.LatLng(45.43, 9.29)];
     var P241 = new google.maps.Polyline({ path: L241, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P241.setMap(map);
 
 
-    var L242 = [ new google.maps.LatLng(38.88, -90.05), new google.maps.LatLng(39.96, -83.0)];
+    var L242 = [ new google.maps.LatLng(15.0, 48.0), new google.maps.LatLng(26.1, 50.46)];
     var P242 = new google.maps.Polyline({ path: L242, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P242.setMap(map);
 
 
-    var L243 = [ new google.maps.LatLng(41.83, 22.0), new google.maps.LatLng(45.43, 9.29)];
+    var L243 = [ new google.maps.LatLng(-12.83, 45.17), new google.maps.LatLng(-33.93, 18.42)];
     var P243 = new google.maps.Polyline({ path: L243, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P243.setMap(map);
 
 
-    var L244 = [ new google.maps.LatLng(37.0, 127.5), new google.maps.LatLng(37.56, 126.98)];
+    var L244 = [ new google.maps.LatLng(-29.0, 24.0), new google.maps.LatLng(1.37, 103.8)];
     var P244 = new google.maps.Polyline({ path: L244, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P244.setMap(map);
 
 
-    var L245 = [ new google.maps.LatLng(13.17, -59.53), new google.maps.LatLng(38.13, -78.45)];
+    var L245 = [ new google.maps.LatLng(-15.0, 30.0), new google.maps.LatLng(53.0, -8.0)];
     var P245 = new google.maps.Polyline({ path: L245, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P245.setMap(map);
 
 
-    var L246 = [ new google.maps.LatLng(38.82, -76.87), new google.maps.LatLng(38.13, -78.45)];
+    var L246 = [ new google.maps.LatLng(-20.0, 30.0), new google.maps.LatLng(53.0, -8.0)];
     var P246 = new google.maps.Polyline({ path: L246, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P246.setMap(map);
 
 
-    var L247 = [ new google.maps.LatLng(-20.0, 47.0), new google.maps.LatLng(-33.93, 18.42)];
+    var L247 = [ new google.maps.LatLng(51.88, -176.65), new google.maps.LatLng(46.15, -123.88)];
     var P247 = new google.maps.Polyline({ path: L247, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P247.setMap(map);
 
 
-    var L248 = [ new google.maps.LatLng(39.0, 22.0), new google.maps.LatLng(45.43, 9.29)];
+    var L248 = [ new google.maps.LatLng(33.58, -85.85), new google.maps.LatLng(39.96, -83.0)];
     var P248 = new google.maps.Polyline({ path: L248, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P248.setMap(map);
 
 
-    var L249 = [ new google.maps.LatLng(24.0, 54.0), new google.maps.LatLng(26.1, 50.46)];
+    var L249 = [ new google.maps.LatLng(35.97, -89.95), new google.maps.LatLng(39.96, -83.0)];
     var P249 = new google.maps.Polyline({ path: L249, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P249.setMap(map);
 
 
-    var L250 = [ new google.maps.LatLng(-21.23, -159.77), new google.maps.LatLng(-33.86, 151.2)];
+    var L250 = [ new google.maps.LatLng(32.17, -110.88), new google.maps.LatLng(37.35, -121.96)];
     var P250 = new google.maps.Polyline({ path: L250, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P250.setMap(map);
 
 
-    var L251 = [ new google.maps.LatLng(-22.0, 24.0), new google.maps.LatLng(53.0, -8.0)];
+    var L251 = [ new google.maps.LatLng(41.48, -120.53), new google.maps.LatLng(37.35, -121.96)];
     var P251 = new google.maps.Polyline({ path: L251, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P251.setMap(map);
 
 
-    var L252 = [ new google.maps.LatLng(6.92, 158.25), new google.maps.LatLng(35.41, 139.42)];
+    var L252 = [ new google.maps.LatLng(39.52, -105.35), new google.maps.LatLng(37.35, -121.96)];
     var P252 = new google.maps.Polyline({ path: L252, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P252.setMap(map);
 
 
-    var L253 = [ new google.maps.LatLng(-10.0, -55.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L253 = [ new google.maps.LatLng(41.17, -73.13), new google.maps.LatLng(45.5, -73.6)];
     var P253 = new google.maps.Polyline({ path: L253, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P253.setMap(map);
 
 
-    var L254 = [ new google.maps.LatLng(54.0, -2.0), new google.maps.LatLng(51.0, -0.1)];
+    var L254 = [ new google.maps.LatLng(38.85, -77.04), new google.maps.LatLng(38.13, -78.45)];
     var P254 = new google.maps.Polyline({ path: L254, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P254.setMap(map);
 
 
-    var L255 = [ new google.maps.LatLng(34.0, 9.0), new google.maps.LatLng(45.43, 9.29)];
+    var L255 = [ new google.maps.LatLng(39.13, -75.47), new google.maps.LatLng(38.13, -78.45)];
     var P255 = new google.maps.Polyline({ path: L255, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P255.setMap(map);
 
 
-    var L256 = [ new google.maps.LatLng(24.25, -76.0), new google.maps.LatLng(38.13, -78.45)];
+    var L256 = [ new google.maps.LatLng(29.73, -85.03), new google.maps.LatLng(38.13, -78.45)];
     var P256 = new google.maps.Polyline({ path: L256, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P256.setMap(map);
 
 
-    var L257 = [ new google.maps.LatLng(18.25, -77.5), new google.maps.LatLng(38.13, -78.45)];
+    var L257 = [ new google.maps.LatLng(31.53, -84.18), new google.maps.LatLng(38.13, -78.45)];
     var P257 = new google.maps.Polyline({ path: L257, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P257.setMap(map);
 
 
-    var L258 = [ new google.maps.LatLng(-6.0, 71.5), new google.maps.LatLng(19.08, 72.88)];
+    var L258 = [ new google.maps.LatLng(21.53, -158.12), new google.maps.LatLng(37.35, -121.96)];
     var P258 = new google.maps.Polyline({ path: L258, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P258.setMap(map);
 
 
-    var L259 = [ new google.maps.LatLng(18.03, -63.13), new google.maps.LatLng(38.13, -78.45)];
+    var L259 = [ new google.maps.LatLng(40.78, -91.12), new google.maps.LatLng(39.96, -83.0)];
     var P259 = new google.maps.Polyline({ path: L259, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P259.setMap(map);
 
 
-    var L260 = [ new google.maps.LatLng(59.0, -105.0), new google.maps.LatLng(46.15, -123.88)];
+    var L260 = [ new google.maps.LatLng(43.57, -116.22), new google.maps.LatLng(46.15, -123.88)];
     var P260 = new google.maps.Polyline({ path: L260, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P260.setMap(map);
 
 
-    var L261 = [ new google.maps.LatLng(16.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
+    var L261 = [ new google.maps.LatLng(38.88, -90.05), new google.maps.LatLng(39.96, -83.0)];
     var P261 = new google.maps.Polyline({ path: L261, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P261.setMap(map);
 
 
-    var L262 = [ new google.maps.LatLng(26.0, 50.55), new google.maps.LatLng(26.1, 50.46)];
+    var L262 = [ new google.maps.LatLng(39.38, -86.5), new google.maps.LatLng(39.96, -83.0)];
     var P262 = new google.maps.Polyline({ path: L262, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P262.setMap(map);
 
 
-    var L263 = [ new google.maps.LatLng(33.0, 44.0), new google.maps.LatLng(26.1, 50.46)];
+    var L263 = [ new google.maps.LatLng(37.67, -95.48), new google.maps.LatLng(39.96, -83.0)];
     var P263 = new google.maps.Polyline({ path: L263, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P263.setMap(map);
 
 
-    var L264 = [ new google.maps.LatLng(39.5, -8.0), new google.maps.LatLng(48.86, 2.35)];
+    var L264 = [ new google.maps.LatLng(36.97, -86.43), new google.maps.LatLng(39.96, -83.0)];
     var P264 = new google.maps.Polyline({ path: L264, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P264.setMap(map);
 
 
-    var L265 = [ new google.maps.LatLng(41.17, -73.13), new google.maps.LatLng(45.5, -73.6)];
+    var L265 = [ new google.maps.LatLng(31.38, -92.3), new google.maps.LatLng(39.96, -83.0)];
     var P265 = new google.maps.Polyline({ path: L265, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P265.setMap(map);
 
 
-    var L266 = [ new google.maps.LatLng(45.17, 15.5), new google.maps.LatLng(45.43, 9.29)];
+    var L266 = [ new google.maps.LatLng(42.47, -71.28), new google.maps.LatLng(45.5, -73.6)];
     var P266 = new google.maps.Polyline({ path: L266, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P266.setMap(map);
 
 
-    var L267 = [ new google.maps.LatLng(-20.0, 30.0), new google.maps.LatLng(53.0, -8.0)];
+    var L267 = [ new google.maps.LatLng(38.82, -76.87), new google.maps.LatLng(38.13, -78.45)];
     var P267 = new google.maps.Polyline({ path: L267, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P267.setMap(map);
 
 
-    var L268 = [ new google.maps.LatLng(13.0, -2.0), new google.maps.LatLng(45.43, 9.29)];
+    var L268 = [ new google.maps.LatLng(44.32, -69.8), new google.maps.LatLng(45.5, -73.6)];
     var P268 = new google.maps.Polyline({ path: L268, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P268.setMap(map);
 
 
-    var L269 = [ new google.maps.LatLng(62.0, 10.0), new google.maps.LatLng(59.25, 17.81)];
+    var L269 = [ new google.maps.LatLng(45.07, -83.57), new google.maps.LatLng(39.96, -83.0)];
     var P269 = new google.maps.Polyline({ path: L269, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P269.setMap(map);
 
 
-    var L270 = [ new google.maps.LatLng(47.0, 29.0), new google.maps.LatLng(45.43, 9.29)];
+    var L270 = [ new google.maps.LatLng(43.68, -93.37), new google.maps.LatLng(39.96, -83.0)];
     var P270 = new google.maps.Polyline({ path: L270, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P270.setMap(map);
 
 
-    var L271 = [ new google.maps.LatLng(-13.3, -176.2), new google.maps.LatLng(-33.86, 151.2)];
+    var L271 = [ new google.maps.LatLng(38.82, -92.22), new google.maps.LatLng(39.96, -83.0)];
     var P271 = new google.maps.Polyline({ path: L271, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P271.setMap(map);
 
 
-    var L272 = [ new google.maps.LatLng(33.58, -85.85), new google.maps.LatLng(39.96, -83.0)];
+    var L272 = [ new google.maps.LatLng(33.65, -88.45), new google.maps.LatLng(39.96, -83.0)];
     var P272 = new google.maps.Polyline({ path: L272, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P272.setMap(map);
 
 
-    var L273 = [ new google.maps.LatLng(64.0, 26.0), new google.maps.LatLng(59.25, 17.81)];
+    var L273 = [ new google.maps.LatLng(45.8, -108.53), new google.maps.LatLng(46.15, -123.88)];
     var P273 = new google.maps.Polyline({ path: L273, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P273.setMap(map);
 
 
-    var L274 = [ new google.maps.LatLng(47.0, 8.0), new google.maps.LatLng(45.43, 9.29)];
+    var L274 = [ new google.maps.LatLng(35.43, -82.55), new google.maps.LatLng(38.13, -78.45)];
     var P274 = new google.maps.Polyline({ path: L274, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P274.setMap(map);
 
 
-    var L275 = [ new google.maps.LatLng(13.0, 105.0), new google.maps.LatLng(1.37, 103.8)];
+    var L275 = [ new google.maps.LatLng(46.77, -100.75), new google.maps.LatLng(39.96, -83.0)];
     var P275 = new google.maps.Polyline({ path: L275, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P275.setMap(map);
 
 
-    var L276 = [ new google.maps.LatLng(36.48, -82.4), new google.maps.LatLng(39.96, -83.0)];
+    var L276 = [ new google.maps.LatLng(42.58, -99.98), new google.maps.LatLng(39.96, -83.0)];
     var P276 = new google.maps.Polyline({ path: L276, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P276.setMap(map);
 
 
-    var L277 = [ new google.maps.LatLng(6.5, -9.5), new google.maps.LatLng(45.43, 9.29)];
+    var L277 = [ new google.maps.LatLng(44.58, -71.18), new google.maps.LatLng(45.5, -73.6)];
     var P277 = new google.maps.Polyline({ path: L277, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P277.setMap(map);
 
 
-    var L278 = [ new google.maps.LatLng(-21.1, 55.6), new google.maps.LatLng(-33.93, 18.42)];
+    var L278 = [ new google.maps.LatLng(39.45, -74.57), new google.maps.LatLng(38.13, -78.45)];
     var P278 = new google.maps.Polyline({ path: L278, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P278.setMap(map);
 
 
-    var L279 = [ new google.maps.LatLng(35.43, -82.55), new google.maps.LatLng(38.13, -78.45)];
+    var L279 = [ new google.maps.LatLng(35.05, -106.6), new google.maps.LatLng(37.35, -121.96)];
     var P279 = new google.maps.Polyline({ path: L279, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P279.setMap(map);
 
 
-    var L280 = [ new google.maps.LatLng(22.17, 113.55), new google.maps.LatLng(22.27, 114.16)];
+    var L280 = [ new google.maps.LatLng(39.83, -117.13), new google.maps.LatLng(37.35, -121.96)];
     var P280 = new google.maps.Polyline({ path: L280, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P280.setMap(map);
 
 
-    var L281 = [ new google.maps.LatLng(-29.0, 24.0), new google.maps.LatLng(1.37, 103.8)];
+    var L281 = [ new google.maps.LatLng(42.75, -73.8), new google.maps.LatLng(45.5, -73.6)];
     var P281 = new google.maps.Polyline({ path: L281, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P281.setMap(map);
 
 
-    var L282 = [ new google.maps.LatLng(23.5, 121.0), new google.maps.LatLng(22.27, 114.16)];
+    var L282 = [ new google.maps.LatLng(39.21, -82.23), new google.maps.LatLng(39.96, -83.0)];
     var P282 = new google.maps.Polyline({ path: L282, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P282.setMap(map);
 
 
-    var L283 = [ new google.maps.LatLng(4.0, -56.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L283 = [ new google.maps.LatLng(34.67, -99.27), new google.maps.LatLng(39.96, -83.0)];
     var P283 = new google.maps.Polyline({ path: L283, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P283.setMap(map);
 
 
-    var L284 = [ new google.maps.LatLng(44.0, 18.0), new google.maps.LatLng(45.43, 9.29)];
+    var L284 = [ new google.maps.LatLng(46.15, -123.88), new google.maps.LatLng(46.15, -123.88)];
     var P284 = new google.maps.Polyline({ path: L284, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P284.setMap(map);
 
 
-    var L285 = [ new google.maps.LatLng(7.85, 25.19), new google.maps.LatLng(26.1, 50.46)];
+    var L285 = [ new google.maps.LatLng(40.65, -75.43), new google.maps.LatLng(38.13, -78.45)];
     var P285 = new google.maps.Polyline({ path: L285, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P285.setMap(map);
 
 
-    var L286 = [ new google.maps.LatLng(-30.0, -71.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L286 = [ new google.maps.LatLng(41.17, -71.58), new google.maps.LatLng(45.5, -73.6)];
     var P286 = new google.maps.Polyline({ path: L286, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P286.setMap(map);
 
 
-    var L287 = [ new google.maps.LatLng(50.83, 4.0), new google.maps.LatLng(48.86, 2.35)];
+    var L287 = [ new google.maps.LatLng(34.5, -82.72), new google.maps.LatLng(38.13, -78.45)];
     var P287 = new google.maps.Polyline({ path: L287, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P287.setMap(map);
 
 
-    var L288 = [ new google.maps.LatLng(24.0, 90.0), new google.maps.LatLng(19.08, 72.88)];
+    var L288 = [ new google.maps.LatLng(45.45, -98.43), new google.maps.LatLng(39.96, -83.0)];
     var P288 = new google.maps.Polyline({ path: L288, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P288.setMap(map);
 
 
-    var L289 = [ new google.maps.LatLng(-34.0, -64.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L289 = [ new google.maps.LatLng(36.48, -82.4), new google.maps.LatLng(39.96, -83.0)];
     var P289 = new google.maps.Polyline({ path: L289, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P289.setMap(map);
 
 
-    var L290 = [ new google.maps.LatLng(1.37, 103.8), new google.maps.LatLng(1.37, 103.8)];
+    var L290 = [ new google.maps.LatLng(32.42, -99.68), new google.maps.LatLng(39.96, -83.0)];
     var P290 = new google.maps.Polyline({ path: L290, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P290.setMap(map);
 
 
-    var L291 = [ new google.maps.LatLng(45.07, -83.57), new google.maps.LatLng(39.96, -83.0)];
+    var L291 = [ new google.maps.LatLng(38.03, -109.78), new google.maps.LatLng(37.35, -121.96)];
     var P291 = new google.maps.Polyline({ path: L291, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P291.setMap(map);
 
 
-    var L292 = [ new google.maps.LatLng(8.0, 1.17), new google.maps.LatLng(45.43, 9.29)];
+    var L292 = [ new google.maps.LatLng(38.13, -78.45), new google.maps.LatLng(38.13, -78.45)];
     var P292 = new google.maps.Polyline({ path: L292, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P292.setMap(map);
 
 
-    var L293 = [ new google.maps.LatLng(56.0, 24.0), new google.maps.LatLng(59.25, 17.81)];
+    var L293 = [ new google.maps.LatLng(44.47, -73.15), new google.maps.LatLng(45.5, -73.6)];
     var P293 = new google.maps.Polyline({ path: L293, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P293.setMap(map);
 
 
-    var L294 = [ new google.maps.LatLng(19.28, 166.6), new google.maps.LatLng(35.41, 139.42)];
+    var L294 = [ new google.maps.LatLng(48.8, -122.53), new google.maps.LatLng(46.15, -123.88)];
     var P294 = new google.maps.Polyline({ path: L294, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P294.setMap(map);
 
 
-    var L295 = [ new google.maps.LatLng(20.0, 77.0), new google.maps.LatLng(19.08, 72.88)];
+    var L295 = [ new google.maps.LatLng(44.25, -88.52), new google.maps.LatLng(39.96, -83.0)];
     var P295 = new google.maps.Polyline({ path: L295, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P295.setMap(map);
 
 
-    var L296 = [ new google.maps.LatLng(5.0, -59.0), new google.maps.LatLng(-23.34, -46.38)];
+    var L296 = [ new google.maps.LatLng(37.78, -81.12), new google.maps.LatLng(38.13, -78.45)];
     var P296 = new google.maps.Polyline({ path: L296, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P296.setMap(map);
 
 
-    var L297 = [ new google.maps.LatLng(27.5, 90.5), new google.maps.LatLng(19.08, 72.88)];
+    var L297 = [ new google.maps.LatLng(42.5, -107.5), new google.maps.LatLng(37.35, -121.96)];
     var P297 = new google.maps.Polyline({ path: L297, strokeColor: "#FF8378", strokeOpacity: 1.0, strokeWeight: 2 });
     P297.setMap(map);
 

--- a/output/usa.index
+++ b/output/usa.index
@@ -1,54 +1,54 @@
-AA;Armed Forces Americas;us-east-1
-AE;Armed Forces Europe, Middle East, & Canada;us-east-1
-AK;Alaska;us-west-2
-AL;Alabama;us-east-2
-AP;Armed Forces Pacific;us-east-1
-AR;Arkansas;us-east-2
-AZ;Arizona;us-west-1
-CA;California;us-west-1
-CO;Colorado;us-west-1
-CT;Connecticut;ca-central-1
-DC;District of Columbia;us-east-1
-DE;Delaware;us-east-1
-FL;Florida;us-east-1
-GA;Georgia;us-east-1
-HI;Hawaii;us-west-1
-IA;Iowa;us-east-2
-ID;Idaho;us-west-2
-IL;Illinois;us-east-2
-IN;Indiana;us-east-2
-KS;Kansas;us-east-2
-KY;Kentucky;us-east-2
-LA;Louisiana;us-east-2
-MA;Massachusetts;ca-central-1
-MD;Maryland;us-east-1
-ME;Maine;ca-central-1
-MI;Michigan;us-east-2
-MN;Minnesota;us-east-2
-MO;Missouri;us-east-2
-MS;Mississippi;us-east-2
-MT;Montana;us-west-2
-NC;North Carolina;us-east-1
-ND;North Dakota;us-east-2
-NE;Nebraska;us-east-2
-NH;New Hampshire;ca-central-1
-NJ;New Jersey;us-east-1
-NM;New Mexico;us-west-1
-NV;Nevada;us-west-1
-NY;New York;ca-central-1
-OH;Ohio;us-east-2
-OK;Oklahoma;us-east-2
-OR;Oregon;us-west-2
-PA;Pennsylvania;us-east-1
-RI;Rhode Island;ca-central-1
-SC;South Carolina;us-east-1
-SD;South Dakota;us-east-2
-TN;Tennessee;us-east-2
-TX;Texas;us-east-2
-UT;Utah;us-west-1
-VA;Virginia;us-east-1
-VT;Vermont;ca-central-1
-WA;Washington;us-west-2
-WI;Wisconsin;us-east-2
-WV;West Virginia;us-east-1
-WY;Wyoming;us-west-1
+AA;Armed Forces Americas;us-east-1;None
+AE;Armed Forces Europe, Middle East, & Canada;us-east-1;None
+AK;Alaska;us-west-2;us-west-2,ap-northeast-1,ap-northeast-3,us-west-1,ap-northeast-2,ap-east-1,us-east-2,ca-central-1,us-east-1,eu-north-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,ap-southeast-1,eu-south-1,ap-south-1,ap-southeast-2,me-south-1,sa-east-1,af-south-1
+AL;Alabama;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,sa-east-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+AP;Armed Forces Pacific;us-east-1;None
+AR;Arkansas;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+AZ;Arizona;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,sa-east-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,ap-southeast-2,me-south-1,ap-south-1,ap-southeast-1,af-south-1
+CA;California;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-north-1,ap-northeast-1,eu-west-2,eu-west-3,ap-northeast-3,eu-central-1,ap-northeast-2,eu-south-1,sa-east-1,ap-east-1,ap-southeast-2,me-south-1,ap-south-1,ap-southeast-1,af-south-1
+CO;Colorado;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,af-south-1
+CT;Connecticut;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+DC;District of Columbia;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,me-south-1,ap-northeast-2,ap-northeast-3,af-south-1,ap-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+DE;Delaware;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,af-south-1,ap-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+FL;Florida;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,sa-east-1,eu-west-3,eu-central-1,eu-north-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+GA;Georgia;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,sa-east-1,eu-central-1,eu-north-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+HI;Hawaii;us-west-1;us-west-1,us-west-2,ap-northeast-1,ap-northeast-3,us-east-2,ap-northeast-2,us-east-1,ca-central-1,ap-southeast-2,ap-east-1,ap-southeast-1,eu-north-1,eu-west-1,eu-west-2,eu-central-1,eu-west-3,eu-south-1,ap-south-1,sa-east-1,me-south-1,af-south-1
+IA;Iowa;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+ID;Idaho;us-west-2;us-west-2,us-west-1,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,ap-northeast-1,ap-northeast-3,eu-south-1,ap-northeast-2,sa-east-1,ap-east-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,af-south-1
+IL;Illinois;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+IN;Indiana;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+KS;Kansas;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-2,af-south-1,ap-southeast-1
+KY;Kentucky;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,af-south-1,ap-south-1,ap-southeast-2,ap-southeast-1
+LA;Louisiana;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,sa-east-1,eu-central-1,eu-north-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,af-south-1,ap-southeast-2,ap-south-1,ap-southeast-1
+MA;Massachusetts;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+MD;Maryland;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,af-south-1,ap-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+ME;Maine;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+MI;Michigan;us-east-2;us-east-2,ca-central-1,us-east-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-1,ap-southeast-2
+MN;Minnesota;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+MO;Missouri;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+MS;Mississippi;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,sa-east-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,af-south-1,ap-south-1,ap-southeast-2,ap-southeast-1
+MT;Montana;us-west-2;us-west-2,us-west-1,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,sa-east-1,ap-east-1,me-south-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1
+NC;North Carolina;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+ND;North Dakota;us-east-2;us-east-2,us-west-2,us-west-1,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,sa-east-1,me-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1
+NE;Nebraska;us-east-2;us-east-2,us-east-1,us-west-2,us-west-1,ca-central-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1
+NH;New Hampshire;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+NJ;New Jersey;us-east-1;us-east-1,ca-central-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,af-south-1,ap-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+NM;New Mexico;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,ap-east-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,af-south-1
+NV;Nevada;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,ap-northeast-1,eu-central-1,ap-northeast-3,eu-south-1,ap-northeast-2,sa-east-1,ap-east-1,ap-southeast-2,me-south-1,ap-south-1,ap-southeast-1,af-south-1
+NY;New York;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+OH;Ohio;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-2,ap-southeast-1
+OK;Oklahoma;us-east-2;us-east-2,us-east-1,us-west-1,us-west-2,ca-central-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,sa-east-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-southeast-2,ap-south-1,af-south-1,ap-southeast-1
+OR;Oregon;us-west-2;us-west-2,us-west-1,us-east-2,us-east-1,ca-central-1,eu-west-1,ap-northeast-1,eu-north-1,eu-west-2,ap-northeast-3,eu-west-3,ap-northeast-2,eu-central-1,eu-south-1,ap-east-1,sa-east-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,af-south-1
+PA;Pennsylvania;us-east-1;us-east-1,ca-central-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+RI;Rhode Island;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,af-south-1,ap-east-1,ap-southeast-1,ap-southeast-2
+SC;South Carolina;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,sa-east-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+SD;South Dakota;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1
+TN;Tennessee;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-east-1,ap-south-1,ap-southeast-2,ap-southeast-1
+TX;Texas;us-east-2;us-east-2,us-east-1,us-west-1,us-west-2,ca-central-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,sa-east-1,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-southeast-2,ap-south-1,af-south-1,ap-southeast-1
+UT;Utah;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ap-northeast-1,sa-east-1,ap-northeast-3,ap-northeast-2,ap-east-1,me-south-1,ap-southeast-2,ap-south-1,ap-southeast-1,af-south-1
+VA;Virginia;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,me-south-1,ap-northeast-3,ap-northeast-2,af-south-1,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+VT;Vermont;ca-central-1;ca-central-1,us-east-1,us-east-2,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,me-south-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-east-1,af-south-1,ap-southeast-1,ap-southeast-2
+WA;Washington;us-west-2;us-west-2,us-west-1,us-east-2,ca-central-1,us-east-1,eu-west-1,eu-north-1,eu-west-2,ap-northeast-1,eu-west-3,ap-northeast-3,eu-central-1,ap-northeast-2,eu-south-1,ap-east-1,sa-east-1,me-south-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1
+WI;Wisconsin;us-east-2;us-east-2,us-east-1,ca-central-1,us-west-2,us-west-1,eu-west-1,eu-west-2,eu-west-3,eu-north-1,eu-central-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,ap-east-1,ap-south-1,af-south-1,ap-southeast-1,ap-southeast-2
+WV;West Virginia;us-east-1;us-east-1,us-east-2,ca-central-1,us-west-1,us-west-2,eu-west-1,eu-west-2,eu-west-3,eu-central-1,eu-north-1,eu-south-1,sa-east-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,me-south-1,af-south-1,ap-south-1,ap-east-1,ap-southeast-2,ap-southeast-1
+WY;Wyoming;us-west-1;us-west-1,us-west-2,us-east-2,us-east-1,ca-central-1,eu-west-1,eu-west-2,eu-north-1,eu-west-3,eu-central-1,eu-south-1,ap-northeast-1,ap-northeast-3,ap-northeast-2,sa-east-1,ap-east-1,me-south-1,ap-south-1,ap-southeast-2,ap-southeast-1,af-south-1


### PR DESCRIPTION
- Hammer until works under Python 3 (not an expert, by far)
- Using the same logic to calculate "the closest DC", also calculate a comma-separated ordered list of "closest DCs"

This should be useful for people who don't have presence in all possible DC's, that way you can use the 2nd or 3rd closest if that's all you can afford ;-)
